### PR TITLE
No need to cast Authentication instance from ApiClient::getAuthentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ public class Main {
 
         AlgodClient client = new AlgodClient();
         client.setBasePath(ALGOD_API_ADDR);
-        ApiKeyAuth api_key = (ApiKeyAuth) client.getAuthentication("api_key");
+        ApiKeyAuth api_key = client.getAuthentication("api_key");
         api_key.setApiKey(ALGOD_API_TOKEN);
 
         AlgodApi algodApiInstance = new AlgodApi(client);

--- a/examples/src/main/java/com/algorand/algosdk/example/Main.java
+++ b/examples/src/main/java/com/algorand/algosdk/example/Main.java
@@ -34,7 +34,7 @@ public class Main {
         AlgodClient client = new AlgodClient();
         client.setBasePath(ALGOD_API_ADDR);
         // Configure API key authorization: api_key
-        ApiKeyAuth api_key = (ApiKeyAuth) client.getAuthentication("api_key");
+        ApiKeyAuth api_key = client.getAuthentication("api_key");
         api_key.setApiKey(ALGOD_API_TOKEN);
 
         AlgodApi algodApiInstance = new AlgodApi(client);
@@ -96,7 +96,7 @@ public class Main {
         KmdClient client = new KmdClient();
         client.setBasePath(KMD_API_ADDR);
         // Configure API key authorization: api_key
-        com.algorand.algosdk.kmd.client.auth.ApiKeyAuth api_key = (com.algorand.algosdk.kmd.client.auth.ApiKeyAuth) client.getAuthentication("api_key");
+        com.algorand.algosdk.kmd.client.auth.ApiKeyAuth api_key = client.getAuthentication("api_key");
         api_key.setApiKey(KMD_API_TOKEN);
         KmdApi kmdApiInstance = new KmdApi(client);
 

--- a/src/main/java/com/algorand/algosdk/algod/client/ApiClient.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ApiClient.java
@@ -261,8 +261,8 @@ public class ApiClient {
      * @param authName The authentication name
      * @return The authentication, null if not found
      */
-    public Authentication getAuthentication(String authName) {
-        return authentications.get(authName);
+    public <T extends Authentication> T getAuthentication(String authName) {
+        return (T) authentications.get(authName);
     }
 
     /**

--- a/src/main/java/com/algorand/algosdk/kmd/client/ApiClient.java
+++ b/src/main/java/com/algorand/algosdk/kmd/client/ApiClient.java
@@ -260,8 +260,8 @@ public class ApiClient {
      * @param authName The authentication name
      * @return The authentication, null if not found
      */
-    public Authentication getAuthentication(String authName) {
-        return authentications.get(authName);
+    public <T extends Authentication> T getAuthentication(String authName) {
+        return (T) authentications.get(authName);
     }
 
     /**


### PR DESCRIPTION
Both implementations of getAuthentication(...) on the ApiClient classes (algorand, kmdApi) are now generic.

The methods are able to deduce the return type based on the receiving variable, no need to be doing the cast every time we invoke `client.getAuthentication("...")`

Cheers!