### PR TITLE
Shant/java example readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ More information can be found at https://blog.bazel.build/2019/03/31/rules-jvm-e
 
 We should monitor the progress of features such as artifact checksumming.
 
-To run the example project:
+To run the example project, run the following command with the algod
+network address and the API token parameters (see examples/README
+for more information):
 ```
-bazel run //examples/src/main/java/com/algorand/algosdk/example:example
+bazel run //examples/src/main/java/com/algorand/algosdk/example:example -- 127.0.0.1:8080 ***X-Algo-API-Token***
 ```
 
 To build the whole library:

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,12 +8,18 @@
    command with the address from the file.
 
 2. Find the X-Algo-API-Token from algod.token file within the data
-   directory of your algod install. Replace <X-Algo-API-Token> in the
+   directory of your algod install. Replace ***X-Algo-API-Token*** in the
    mvn command with the token from the file.
 
+To run the example using bazel:
+```
+bazel run //examples/src/main/java/com/algorand/algosdk/example:example  -- 127.0.0.1:8080 ***X-Algo-API-Token***
+```
+
+To run the example using maven:
 ```
 cd examples
-mvn clean install -Dexec.cleanupDaemonThreads=false exec:java -Dexec.mainClass="com.algorand.algosdk.example.Main" -Dexec.args="127.0.0.1:8080 <X-Algo-API-Token>"
+mvn clean install -Dexec.cleanupDaemonThreads=false exec:java -Dexec.mainClass="com.algorand.algosdk.example.Main" -Dexec.args="127.0.0.1:8080 ***X-Algo-API-Token***"
 ```
 Output (for instance):
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,9 +2,18 @@
 # Java AlgoSDK Example Project
 
 ## Quickstart
+
+1. Find the algod network address from algod.net file within the data
+   directory of your algod install. Replace 127.0.0.1:8080 in the mvn
+   command with the address from the file.
+
+2. Find the X-Algo-API-Token from algod.token file within the data
+   directory of your algod install. Replace <X-Algo-API-Token> in the
+   mvn command with the token from the file.
+
 ```
 cd examples
-mvn clean install exec:java -Dexec.mainClass="com.algorand.algosdk.example.Main"
+mvn clean install -Dexec.cleanupDaemonThreads=false exec:java -Dexec.mainClass="com.algorand.algosdk.example.Main" -Dexec.args="127.0.0.1:8080 <X-Algo-API-Token>"
 ```
 Output (for instance):
 ```
@@ -12,6 +21,8 @@ Total Algorand Supply: 10011480163524162
 Online Algorand Supply: 9911265198066763
 Suggested Fee: 9875
 Current Round: 275938
+Attempting an invalid transaction: overspending using randomly generated accounts.
+Expecting overspend exception.
 Signed transaction with txid: AWHALXA3D4BV5URKY332X6U5W7HIHQZVDSNBRZZDRA2EGIK3IB4A
 Exception when calling algod#rawTransaction: TransactionPool.Remember: Insufficient funds - The total pending transactions from the address require 9975 Algos but the account only has 0 Algos
 ```

--- a/examples/src/main/java/com/algorand/algosdk/example/Main.java
+++ b/examples/src/main/java/com/algorand/algosdk/example/Main.java
@@ -19,15 +19,29 @@ import com.algorand.algosdk.transaction.SignedTransaction;
 import com.algorand.algosdk.transaction.Transaction;
 import com.algorand.algosdk.util.Encoder;
 
-import java.security.Security;
+import com.squareup.okhttp.HttpUrl;
+
 import java.math.BigInteger;
+
 
 
 public class Main {
 
     public static void main(String args[]) throws Exception {
-        final String ALGOD_API_ADDR = "http://localhost:8080";
-        final String ALGOD_API_TOKEN = "b3ff7b3765bf33c7557a2cd334238eca07578e3ce266cb03fad93d12aab0622e";
+        if (args.length != 2) {
+            System.err.println("Required parameters: ALGOD_API_ADDR ALGOD_API_TOKEN");
+            System.err.println("The parameter values can be found in algod.net and algod.token files within the data directory of your algod install.");
+            System.exit(1);
+        }
+
+        // If the protocol is not specified in the address, http is added.
+        String algodApiAddrTmp = args[0];
+        if (HttpUrl.parse(algodApiAddrTmp) == null) {
+            algodApiAddrTmp = "http://" + algodApiAddrTmp;
+        }
+
+        final String ALGOD_API_ADDR = algodApiAddrTmp;
+        final String ALGOD_API_TOKEN = args[1];
         final String SRC_ACCOUNT = "viable grain female caution grant mind cry mention pudding oppose orchard people forget similar social gossip marble fish guitar art morning ring west above concert";
         final String DEST_ADDR = "KV2XGKMXGYJ6PWYQA5374BYIQBL3ONRMSIARPCFCJEAMAHQEVYPB7PL3KU";
 
@@ -68,6 +82,9 @@ public class Main {
         }
 
         // Generate a new transaction using randomly generated accounts (this is invalid, since src has no money...)
+        System.out.println("Attempting an invalid transaction: overspending using randomly generated accounts.");
+        System.out.println("Expecting overspend exception.");
+
         long amount = 100000;
         long lastRound = firstRound + 1000; // 1000 is the max tx window
         Transaction tx = new Transaction(src.getAddress(), new Address(DEST_ADDR), amount, firstRound, lastRound, genesisID, genesisHash);
@@ -83,9 +100,6 @@ public class Main {
             // This is generally expected, but should give us an informative error message.
             System.err.println("Exception when calling algod#rawTransaction: " + e.getResponseBody());
         }
-
-        // now, demo kmd api
-//        kmdApi();
     }
 
     public static void kmdApi() {

--- a/examples/src/main/java/com/algorand/algosdk/example/Main.java
+++ b/examples/src/main/java/com/algorand/algosdk/example/Main.java
@@ -19,8 +19,6 @@ import com.algorand.algosdk.transaction.SignedTransaction;
 import com.algorand.algosdk.transaction.Transaction;
 import com.algorand.algosdk.util.Encoder;
 
-import com.squareup.okhttp.HttpUrl;
-
 import java.math.BigInteger;
 
 
@@ -36,7 +34,7 @@ public class Main {
 
         // If the protocol is not specified in the address, http is added.
         String algodApiAddrTmp = args[0];
-        if (HttpUrl.parse(algodApiAddrTmp) == null) {
+        if (algodApiAddrTmp.indexOf("//") == -1) {
             algodApiAddrTmp = "http://" + algodApiAddrTmp;
         }
 


### PR DESCRIPTION
1. The algod network address and token are hard-coded in the Java demo
program. Changing the program to expect these values as parameters.

2. Adding standard output messages to expect an overspending exception
before the error message is printed out.

3. algod.net address does not specify the http protocol. Adding logic
to the example program to amend the protocol if not specified in the
address passed as an argument.

4. Updating the README.md file to describe how to add the algod
network address and token parameters.

5. Adding cleanupDaemonThreads=false flag to prevent maven from
throwing java.lang.IllegalThreadStateException

6. Removing unused import from the java file.