### PR TITLE
[Important] - Change the word setupIfNeeded to setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+# 1.1.6
+## Changed
+- IMPORTANT - This version modifies one of the mnemonic words. Please let your users to know that if they have the word "setupIfNeeded" in their mmnemonic, they should change it to "setup". Everything else remains the same. 
 # 1.1.5
 ## Added
 - signing and verifying signatures for arbitrary bytes

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+| IMPORTANT <br /> Version 1.1.6 modifies one of the mnemonic words. Please let your users know that if they have the word "setupIfNeeded" in their passphrase, they should change it to "setup". Everything else remains the same.|
+|---| 
+
 # java-algorand-sdk
 
 [![Build Status](https://travis-ci.com/algorand/java-algorand-sdk.svg?branch=master)](https://travis-ci.com/algorand/java-algorand-sdk?branch=master)

--- a/src/main/java/com/algorand/algosdk/mnemonic/Wordlist.java
+++ b/src/main/java/com/algorand/algosdk/mnemonic/Wordlist.java
@@ -1,6 +1,9 @@
 package com.algorand.algosdk.mnemonic;
 
+import java.util.Arrays;
+
 public class Wordlist {
+    private static final String RAW_CHECKSUM = "cancel";
     public static final String[] RAW = new String[]{
             "abandon",
             "ability",
@@ -2051,4 +2054,11 @@ public class Wordlist {
             "zone",
             "zoo",
     };
+
+    // check that the words we'rent modified
+    static {
+        if (!Mnemonic.checksum(Arrays.toString(RAW).getBytes()).equals(RAW_CHECKSUM)) {
+            throw new RuntimeException("cannot initialize passphrase library: wordlist corrupted");
+        }
+    }
 }

--- a/src/main/java/com/algorand/algosdk/mnemonic/Wordlist.java
+++ b/src/main/java/com/algorand/algosdk/mnemonic/Wordlist.java
@@ -1574,7 +1574,7 @@ public class Wordlist {
             "service",
             "session",
             "settle",
-            "setupIfNeeded",
+            "setup",
             "seven",
             "shadow",
             "shaft",


### PR DESCRIPTION
-- This is an important fix. 

Apparently, there was a typo in one of the Mnemonic words. Luckily, the fix is simple and there are no severe consequences. When one upgrades to this patch, there is a need to let the users know that if they have the word "setupIfNeeded" in their passphrase, they should change it to "setup". Everything else remains the same and it doesn't affect their private keys.