### PR TITLE
Shant/testtransactionchanges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: java
 
+before_script:
+  - echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+  - curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get install bazel -y
+
 install:
   - curl https://raw.githubusercontent.com/algorand/algorand-sdk-testing/master/scripts/sdkupdate.sh -o ~/sdkupdate.sh
   - chmod +x ~/sdkupdate.sh
 
 script:
   - mvn test -q
+  - bazel test //... --incompatible_depset_is_not_iterable=false
   - ~/sdkupdate.sh --java

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,9 +2,18 @@
 # Java AlgoSDK Example Project
 
 ## Quickstart
+
+1. Find the algod network address from algod.net file within the data
+   directory of your algod install. Replace 127.0.0.1:8080 in the mvn
+   command with the address from the file.
+
+2. Find the X-Algo-API-Token from algod.token file within the data
+   directory of your algod install. Replace <X-Algo-API-Token> in the
+   mvn command with the token from the file.
+
 ```
 cd examples
-mvn clean install exec:java -Dexec.mainClass="com.algorand.algosdk.example.Main"
+mvn clean install -Dexec.cleanupDaemonThreads=false exec:java -Dexec.mainClass="com.algorand.algosdk.example.Main" -Dexec.args="127.0.0.1:8080 <X-Algo-API-Token>"
 ```
 Output (for instance):
 ```
@@ -12,6 +21,8 @@ Total Algorand Supply: 10011480163524162
 Online Algorand Supply: 9911265198066763
 Suggested Fee: 9875
 Current Round: 275938
+Attempting an invalid transaction: overspending using randomly generated accounts.
+Expecting overspend exception.
 Signed transaction with txid: AWHALXA3D4BV5URKY332X6U5W7HIHQZVDSNBRZZDRA2EGIK3IB4A
 Exception when calling algod#rawTransaction: TransactionPool.Remember: Insufficient funds - The total pending transactions from the address require 9975 Algos but the account only has 0 Algos
 ```

--- a/examples/src/main/java/com/algorand/algosdk/example/Main.java
+++ b/examples/src/main/java/com/algorand/algosdk/example/Main.java
@@ -19,15 +19,29 @@ import com.algorand.algosdk.transaction.SignedTransaction;
 import com.algorand.algosdk.transaction.Transaction;
 import com.algorand.algosdk.util.Encoder;
 
-import java.security.Security;
+import com.squareup.okhttp.HttpUrl;
+
 import java.math.BigInteger;
+
 
 
 public class Main {
 
     public static void main(String args[]) throws Exception {
-        final String ALGOD_API_ADDR = "http://localhost:8080";
-        final String ALGOD_API_TOKEN = "b3ff7b3765bf33c7557a2cd334238eca07578e3ce266cb03fad93d12aab0622e";
+        if (args.length != 2) {
+            System.err.println("Required parameters: ALGOD_API_ADDR ALGOD_API_TOKEN");
+            System.err.println("The parameter values can be found in algod.net and algod.token files within the data directory of your algod install.");
+            System.exit(1);
+        }
+
+        // If the protocol is not specified in the address, http is added.
+        String algodApiAddrTmp = args[0];
+        if (HttpUrl.parse(algodApiAddrTmp) == null) {
+            algodApiAddrTmp = "http://" + algodApiAddrTmp;
+        }
+
+        final String ALGOD_API_ADDR = algodApiAddrTmp;
+        final String ALGOD_API_TOKEN = args[1];
         final String SRC_ACCOUNT = "viable grain female caution grant mind cry mention pudding oppose orchard people forget similar social gossip marble fish guitar art morning ring west above concert";
         final String DEST_ADDR = "KV2XGKMXGYJ6PWYQA5374BYIQBL3ONRMSIARPCFCJEAMAHQEVYPB7PL3KU";
 
@@ -68,6 +82,9 @@ public class Main {
         }
 
         // Generate a new transaction using randomly generated accounts (this is invalid, since src has no money...)
+        System.out.println("Attempting an invalid transaction: overspending using randomly generated accounts.");
+        System.out.println("Expecting overspend exception.");
+
         long amount = 100000;
         long lastRound = firstRound + 1000; // 1000 is the max tx window
         Transaction tx = new Transaction(src.getAddress(), new Address(DEST_ADDR), amount, firstRound, lastRound, genesisID, genesisHash);
@@ -83,9 +100,6 @@ public class Main {
             // This is generally expected, but should give us an informative error message.
             System.err.println("Exception when calling algod#rawTransaction: " + e.getResponseBody());
         }
-
-        // now, demo kmd api
-//        kmdApi();
     }
 
     public static void kmdApi() {

--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -4,11 +4,19 @@ package com.algorand.algosdk.transaction;
 import com.algorand.algosdk.crypto.Address;
 import com.algorand.algosdk.crypto.Digest;
 import com.algorand.algosdk.crypto.ParticipationPublicKey;
+import com.algorand.algosdk.crypto.Signature;
 import com.algorand.algosdk.crypto.VRFPublicKey;
+import com.algorand.algosdk.util.Digester;
+import com.algorand.algosdk.util.Encoder;
+import com.algorand.algosdk.util.SignatureUtils;
 import com.fasterxml.jackson.annotation.*;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.util.Arrays;
 
 /**
@@ -16,59 +24,261 @@ import java.util.Arrays;
  * This is distinct from algod.model.Transaction, which is only returned for GET requests to algod.
  */
 @JsonPropertyOrder(alphabetic=true)
-@JsonInclude(JsonInclude.Include.NON_DEFAULT)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Transaction implements Serializable {
+
+    private static final byte[] TX_SIGN_PREFIX = ("TX").getBytes(StandardCharsets.UTF_8);
+    private static final BigInteger MIN_TX_FEE_UALGOS = BigInteger.valueOf(1000);
+
     @JsonProperty("type")
     public Type type = Type.Default;
 
     // Instead of embedding POJOs and using JsonUnwrapped, we explicitly export inner fields. This circumvents our encoders'
     // inability to sort child fields.
-    /* header fields */
+    /* header fields ***********************************************************/
     @JsonProperty("snd")
-    public Address sender = new Address();
+    public Address sender;
     @JsonProperty("fee")
-    public BigInteger fee = BigInteger.valueOf(0);
+    public BigInteger fee;
     @JsonProperty("fv")
-    public BigInteger firstValid = BigInteger.valueOf(0);
+    public BigInteger firstValid;
     @JsonProperty("lv")
-    public BigInteger lastValid = BigInteger.valueOf(0);
+    public BigInteger lastValid;
     @JsonProperty("note")
     public byte[] note;
     @JsonProperty("gen")
-    public String genesisID = "";
+    public String genesisID;
     @JsonProperty("gh")
-    public Digest genesisHash = new Digest();
+    public Digest genesisHash;
 
     /* payment fields */
     @JsonProperty("amt")
-    public BigInteger amount = BigInteger.valueOf(0);
+    public BigInteger amount;
     @JsonProperty("rcv")
-    public Address receiver = new Address();
+    public Address receiver;
     @JsonProperty("close")
-    public Address closeRemainderTo = new Address(); // can be null, optional
+    public Address closeRemainderTo;
 
-    /* keyreg fields */
+    /* keyreg fields ***********************************************************/
     // VotePK is the participation public key used in key registration transactions
     @JsonProperty("votekey")
-    public ParticipationPublicKey votePK = new ParticipationPublicKey();
+    public ParticipationPublicKey votePK;
+
     // selectionPK is the VRF public key used in key registration transactions
     @JsonProperty("selkey")
-    public VRFPublicKey selectionPK = new VRFPublicKey();
+    public VRFPublicKey selectionPK;
+
     // voteFirst is the first round this keyreg tx is valid for
     @JsonProperty("votefst")
-    public BigInteger voteFirst = BigInteger.valueOf(0);
+    public BigInteger voteFirst;
+
     // voteLast is the last round this keyreg tx is valid for
     @JsonProperty("votelst")
-    public BigInteger voteLast = BigInteger.valueOf(0);
+    public BigInteger voteLast;
     // voteKeyDilution
+
     @JsonProperty("votekd")
-    public BigInteger voteKeyDilution = BigInteger.valueOf(0);
-    
-    /* asset creation and config fields */
+    public BigInteger voteKeyDilution;
+
+    /* asset creation and configuration fields *********************************/
     @JsonProperty("apar")
-    public AssetParams assetParams = new AssetParams();
+    public AssetParams assetParams;
     @JsonProperty("caid")
-    public AssetID assetID = new AssetID();
+    public AssetID assetID;
+
+    /* asset transfer fields ***************************************************/
+    @JsonProperty("xaid")
+    public AssetID xferAsset;
+
+    // The amount of asset to transfer. A zero amount transferred to self
+    // allocates that asset in the account's Assets map.
+    @JsonProperty("aamt")
+    public BigInteger assetAmount;
+
+    // The sender of the transfer.  If this is not a zero value, the real
+    // transaction sender must be the Clawback address from the AssetParams. If
+    // this is the zero value, the asset is sent from the transaction's Sender.
+    @JsonProperty("asnd")
+    public Address assetSender;
+
+    // The receiver of the transfer.
+    @JsonProperty("arcv")
+    public Address assetReceiver;
+
+    // Indicates that the asset should be removed from the account's Assets map,
+    // and specifies where the remaining asset holdings should be transferred.
+    // It's always valid to transfer remaining asset holdings to the AssetID
+    // account.
+    @JsonProperty("aclose")
+    public Address assetCloseTo;
+
+
+
+
+    /**
+     * Sign a transaction with this account
+     * @param tx the transaction to sign
+     * @return a signed transaction
+     * @throws NoSuchAlgorithmException if signing algorithm could not be found
+     */
+    public SignedTransaction signTransaction(PrivateKey pKey) throws NoSuchAlgorithmException {
+        try {
+            byte[] encodedTx = Encoder.encodeToMsgPack(this);
+            // prepend hashable prefix
+            byte[] prefixEncodedTx = new byte[encodedTx.length + TX_SIGN_PREFIX.length];
+            System.arraycopy(TX_SIGN_PREFIX, 0, prefixEncodedTx, 0, TX_SIGN_PREFIX.length);
+            System.arraycopy(encodedTx, 0, prefixEncodedTx, TX_SIGN_PREFIX.length, encodedTx.length);
+            // sign
+            Signature txSig = new Signature(
+                    SignatureUtils.rawSignBytes(
+                    Arrays.copyOf(
+                            prefixEncodedTx, 
+                            prefixEncodedTx.length), 
+                    pKey));
+            String txID = Encoder.encodeToBase32StripPad(Digester.digest(prefixEncodedTx));
+            return new SignedTransaction(this, txSig, txID);
+        } catch (IOException e) {
+            throw new RuntimeException("unexpected behavior", e);
+        }
+    }
+
+
+
+    /**
+     * Creates a version of the given transaction with fee populated according to suggestedFeePerByte * estimateTxSize.
+     * @param copyTx transaction to populate fee field
+     * @param suggestedFeePerByte suggestedFee given by network
+     * @return transaction with proper fee set
+     * @throws NoSuchAlgorithmException could not estimate tx encoded size.
+     */
+    public void setFeeWithSuggestedFeePerByte(BigInteger suggestedFeePerByte) throws NoSuchAlgorithmException{
+        BigInteger newFee = suggestedFeePerByte.multiply(this.estimatedEncodedSize());
+        this.setFee(newFee);
+    }
+
+    /**
+     * EstimateEncodedSize returns the estimated encoded size of the transaction including the signature.
+     * This function is useful for calculating the fee from suggested fee per byte.
+     * @return an estimated byte size for the transaction.
+     */
+    public BigInteger estimatedEncodedSize() throws NoSuchAlgorithmException {
+        try {
+            return BigInteger.valueOf(
+                    Encoder.encodeToMsgPack(
+                            this.signTransaction(
+                                    SignatureUtils.getDummyPrivateKey().getPrivate())).length);
+        } catch (IOException e) {
+            throw new RuntimeException("unexpected behavior", e);
+        }
+    }
+
+    /**
+     * Set the transaction fee value.
+     **/
+    public void setFee(BigInteger newFee) {
+        if (newFee.compareTo(MIN_TX_FEE_UALGOS) < 0) {
+            newFee = MIN_TX_FEE_UALGOS;
+        }
+        fee = newFee;
+    }
+
+
+
+    /**
+     * Creates a tx to mark the account as willing to accept the asset.
+     * @param acceptingAccount is a checksummed, human-readable address that
+     * will accept receiving the asset.
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    public static Transaction acceptAssetTransaction(Address acceptingAccount, //AssetTransaction
+			    BigInteger flatFee,
+			    BigInteger firstRound,
+			    BigInteger lastRound,
+			    byte [] note,
+			    String genesisID,
+			    Digest genesisHash,
+			    Address assetCreator,
+			    BigInteger assetIndex) {
+
+	Transaction tx = assetTransferTransaction(acceptingAccount,
+	     acceptingAccount,
+	     acceptingAccount,
+	     BigInteger.valueOf(0),
+	     flatFee,
+	     firstRound,
+	     lastRound,
+	     note,
+	     genesisID,
+	     genesisHash,
+	     assetCreator,
+	     assetIndex);
+
+	tx.assetAmount = null;
+	tx.assetCloseTo = null;
+	tx.assetSender = null;
+	tx.genesisID = null;
+
+	return tx;
+    }
+
+    /**
+     * Creates a tx for sending some asset from an asset holder to another user.
+     *  The asset receiver must have marked itself as willing to accept the
+     *  asset.
+     * @param assetSender is a checksummed, human-readable address that will
+     * send the transaction and assets
+     * @param assetReceiver is a checksummed, human-readable address what will
+     * receive the assets
+     * @param assetCloseTo is a checksummed, human-readable address that
+     * behaves as a close-to address for the asset transaction; the remaining
+     * assets not sent to assetReceiver will be sent to assetCloseTo. Leave
+     * blank for no close-to behavior.
+     * @param assetAmount is the number of assets to send
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    public static Transaction assetTransferTransaction(Address assetSender, // AssetTransaction
+						       Address assetReceiver,
+						       Address assetCloseTo,
+						       BigInteger assetAmount,
+						       BigInteger flatFee,
+						       BigInteger firstRound,
+						       BigInteger lastRound,
+						       byte [] note,
+						       String genesisID,
+						       Digest genesisHash,
+						       Address assetCreator,
+						       BigInteger assetIndex) {
+
+	Transaction tx = new Transaction(flatFee, firstRound, lastRound, note, genesisID,
+					 genesisHash, assetCreator, assetIndex);
+	
+	tx.assetSender = assetSender;
+	tx.assetReceiver = assetReceiver;
+	tx.assetCloseTo = assetCloseTo;
+	tx.assetAmount = assetAmount;
+	tx.sender = assetSender;
+
+	return tx;
+    }
+    
     /**
      * Create a payment transaction
      * @param fromAddr source address
@@ -79,13 +289,13 @@ public class Transaction implements Serializable {
      * @param lastRound last valid round
      */
     public Transaction(Address fromAddr, Address toAddr, BigInteger fee, BigInteger amount, BigInteger firstRound,
-                       BigInteger lastRound) {
+            BigInteger lastRound) {
         this(fromAddr, fee, firstRound, lastRound, null, amount, toAddr, "", new Digest());
     }
 
     public Transaction(Address fromAddr, Address toAddr, BigInteger fee, BigInteger amount, BigInteger firstRound,
-                       BigInteger lastRound,
-                       String genesisID, Digest genesisHash) {
+            BigInteger lastRound,
+            String genesisID, Digest genesisHash) {
         this(fromAddr, fee, firstRound, lastRound, null, amount, toAddr, genesisID, genesisHash);
     }
 
@@ -100,17 +310,17 @@ public class Transaction implements Serializable {
      * @param genesisHash genesis hash
      */
     public Transaction(Address fromAddr, Address toAddr, long amount, long firstRound, long lastRound,
-                       String genesisID, Digest genesisHash) {
+            String genesisID, Digest genesisHash) {
         this(fromAddr, BigInteger.valueOf(0), BigInteger.valueOf(firstRound), BigInteger.valueOf(lastRound), null, BigInteger.valueOf(amount), toAddr, genesisID, genesisHash);
     }
 
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       BigInteger amount, Address receiver, String genesisID, Digest genesisHash) {
+            BigInteger amount, Address receiver, String genesisID, Digest genesisHash) {
         this(sender, fee, firstValid, lastValid, note, genesisID, genesisHash, amount, receiver, new Address());
     }
 
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note, String genesisID, Digest genesisHash,
-                       BigInteger amount, Address receiver, Address closeRemainderTo) {
+            BigInteger amount, Address receiver, Address closeRemainderTo) {
         this(Type.Payment, sender, fee, firstValid, lastValid, note, genesisID, genesisHash, amount, receiver, closeRemainderTo,
                 new ParticipationPublicKey(), new VRFPublicKey(), BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(), new AssetParams());
     }
@@ -129,9 +339,9 @@ public class Transaction implements Serializable {
      * @param voteKeyDilution key reg dilution
      */
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       String genesisID, Digest genesisHash,
-                       ParticipationPublicKey votePK, VRFPublicKey vrfPK,
-                       BigInteger voteFirst, BigInteger voteLast, BigInteger voteKeyDilution) {
+            String genesisID, Digest genesisHash,
+            ParticipationPublicKey votePK, VRFPublicKey vrfPK,
+            BigInteger voteFirst, BigInteger voteLast, BigInteger voteKeyDilution) {
         // populate with default values which will be ignored...
         this(Type.KeyRegistration, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
                 BigInteger.valueOf(0), new Address(), new Address(), votePK, vrfPK, voteFirst, voteLast, 
@@ -157,8 +367,8 @@ public class Transaction implements Serializable {
      * @param clawback account which can issue clawbacks against holder accounts
      */
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       String genesisID, Digest genesisHash, BigInteger assetTotal, boolean defaultFrozen,
-                       String assetUnitName, String assetName, Address manager, Address reserve, Address freeze, Address clawback) {
+            String genesisID, Digest genesisHash, BigInteger assetTotal, boolean defaultFrozen,
+            String assetUnitName, String assetName, Address manager, Address reserve, Address freeze, Address clawback) {
         // populate ignored values with default or null values
         this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
                 BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(), 
@@ -184,8 +394,8 @@ public class Transaction implements Serializable {
      * @param clawback account which can issue clawbacks against holder accounts
      */
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       String genesisID, Digest genesisHash, Address creator, BigInteger index,
-                    Address manager, Address reserve, Address freeze, Address clawback) {
+            String genesisID, Digest genesisHash, Address creator, BigInteger index,
+            Address manager, Address reserve, Address freeze, Address clawback) {
         // populate ignored values with default or null values
         this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
                 BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(creator, index), 
@@ -193,55 +403,118 @@ public class Transaction implements Serializable {
     }
 
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       String genesisID, Digest genesisHash, AssetID assetID, AssetParams assetParams) {
+            String genesisID, Digest genesisHash, AssetID assetID, AssetParams assetParams) {
         // populate ignored values with default or null values
         this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
                 BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), assetID, assetParams);
     }
 
-    // workaround for nested JsonValue classes
-    @JsonCreator
-    private Transaction(@JsonProperty("type") Type type,
-                        @JsonProperty("snd") byte[] sender,
-                        @JsonProperty("fee") BigInteger fee,
-                        @JsonProperty("fv") BigInteger firstValid,
-                        @JsonProperty("lv") BigInteger lastValid,
-                        @JsonProperty("note") byte[] note,
-                        @JsonProperty("gen") String genesisID,
-                        @JsonProperty("gh") byte[] genesisHash,
-                        @JsonProperty("amt") BigInteger amount,
-                        @JsonProperty("rcv") byte[] receiver,
-                        @JsonProperty("close") byte[] closeRemainderTo,
-                        @JsonProperty("votekey") byte[] votePK,
-                        @JsonProperty("selkey") byte[] vrfPK,
-                        @JsonProperty("votefst") BigInteger voteFirst,
-                        @JsonProperty("votelst") BigInteger voteLast,
-                        @JsonProperty("votekd") BigInteger voteKeyDilution,
-                        @JsonProperty("caid") AssetID assetID,
-                        @JsonProperty("apar") AssetParams assetParams) {
-        this(type, new Address(sender), fee, firstValid, lastValid, note, genesisID, new Digest(genesisHash), amount,
-                new Address(receiver), new Address(closeRemainderTo), new ParticipationPublicKey(votePK), new VRFPublicKey(vrfPK),
-                voteFirst, voteLast, voteKeyDilution, assetID, assetParams);
+    /**
+     * Base constructor with flat fee for asset xfer transactions.
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    private Transaction(// Asset xfer transaction
+            BigInteger flatFee, 
+            BigInteger firstRound,
+            BigInteger lastRound,
+            byte [] note,
+            String genesisID,
+            Digest genesisHash,
+            Address assetCreator,
+            BigInteger assetIndex) {
+
+        this.type = Type.AssetTransfer;
+        if (flatFee != null) this.fee = flatFee;
+        if (firstRound != null) this.firstValid = firstRound;
+        if (lastRound != null) this.lastValid = lastRound;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        if (assetCreator != null) this.xferAsset = new AssetID(assetCreator,
+                assetIndex);
+
     }
 
+    @JsonCreator
+    private Transaction(@JsonProperty("type") Type type,
+            @JsonProperty("snd") byte[] sender,
+            @JsonProperty("fee") BigInteger fee,
+            @JsonProperty("fv") BigInteger firstValid,
+            @JsonProperty("lv") BigInteger lastValid,
+            @JsonProperty("note") byte[] note,
+            @JsonProperty("gen") String genesisID,
+            @JsonProperty("gh") byte[] genesisHash,
+            @JsonProperty("amt") BigInteger amount,
+            @JsonProperty("rcv") byte[] receiver,
+            @JsonProperty("close") byte[] closeRemainderTo,
+            @JsonProperty("votekey") byte[] votePK,
+            @JsonProperty("selkey") byte[] vrfPK,
+            @JsonProperty("votefst") BigInteger voteFirst,
+            @JsonProperty("votelst") BigInteger voteLast,
+            @JsonProperty("votekd") BigInteger voteKeyDilution,
+            @JsonProperty("caid") AssetID assetID,
+            @JsonProperty("apar") AssetParams assetParams,
+            // Asset xfer transaction fields
+            @JsonProperty("xaid") AssetID xferAsset,
+            @JsonProperty("aamt") BigInteger assetAmount,
+            @JsonProperty("asnd") byte[] assetSender,
+            @JsonProperty("arcv") byte[] assetReceiver,
+            @JsonProperty("aclose") byte[] assetCloseTo) {
+        this(type,
+                new Address(sender),
+                fee,
+                firstValid,
+                lastValid,
+                note,
+                genesisID,
+                new Digest(genesisHash),
+                amount,
+                new Address(receiver),
+                new Address(closeRemainderTo),
+                new ParticipationPublicKey(votePK),
+                new VRFPublicKey(vrfPK),
+                voteFirst,
+                voteLast,
+                voteKeyDilution,
+                assetID,
+                assetParams);
+
+        if(xferAsset != null) {	    
+            this.assetSender = new Address(assetSender);
+            this.assetReceiver = new Address(assetReceiver);
+            this.assetCloseTo = new Address(assetCloseTo);
+            this.assetAmount = assetAmount;
+        }
+    }
+
+
     private Transaction(Type type,
-                        Address sender,
-                        BigInteger fee,
-                        BigInteger firstValid,
-                        BigInteger lastValid,
-                        byte[] note,
-                        String genesisID,
-                        Digest genesisHash,
-                        BigInteger amount,
-                        Address receiver,
-                        Address closeRemainderTo,
-                        ParticipationPublicKey votePK,
-                        VRFPublicKey vrfPK,
-                        BigInteger voteFirst,
-                        BigInteger voteLast,
-                        BigInteger voteKeyDilution,
-                        AssetID assetID,
-                        AssetParams assetParams) {
+            Address sender,
+            BigInteger fee,
+            BigInteger firstValid,
+            BigInteger lastValid,
+            byte[] note,
+            String genesisID,
+            Digest genesisHash,
+            BigInteger amount,
+            Address receiver,
+            Address closeRemainderTo,
+            ParticipationPublicKey votePK,
+            VRFPublicKey vrfPK,
+            BigInteger voteFirst,
+            BigInteger voteLast,
+            BigInteger voteKeyDilution,
+            AssetID assetID,
+            AssetParams assetParams) {
         if (type != null) this.type = type;
         if (sender != null) this.sender = sender;
         if (fee != null) this.fee = fee;
@@ -272,7 +545,8 @@ public class Transaction implements Serializable {
         Default(""),
         Payment("pay"),
         KeyRegistration("keyreg"),
-        AssetConfig("acfg");
+        AssetConfig("acfg"),
+        AssetTransfer("axfer");
 
         private final String value;
         private Type(String value) {
@@ -341,7 +615,7 @@ public class Transaction implements Serializable {
         // the address which has the ability to issue clawbacks against asset-holding accounts
         @JsonProperty("c")
         public Address assetClawback = new Address();
-        
+
         public AssetParams(BigInteger assetTotal, boolean defaultFrozen, String assetUnitName, String assetName, Address manager, Address reserve, Address freeze, Address clawback) {
             if(assetTotal != null) this.assetTotal = assetTotal;
             this.assetDefaultFrozen = defaultFrozen;
@@ -364,24 +638,24 @@ public class Transaction implements Serializable {
             if (o == null || getClass() != o.getClass()) return false;
             AssetParams that = (AssetParams) o;
             return assetTotal.equals(that.assetTotal) &&
-                (assetDefaultFrozen == that.assetDefaultFrozen) &&
-                assetName.equals(that.assetName) &&
-                assetUnitName.equals(that.assetUnitName) &&
-                assetManager.equals(that.assetManager) &&
-                assetReserve.equals(that.assetReserve) &&
-                assetFreeze.equals(that.assetFreeze) &&
-                assetClawback.equals(that.assetClawback);
+                    (assetDefaultFrozen == that.assetDefaultFrozen) &&
+                    assetName.equals(that.assetName) &&
+                    assetUnitName.equals(that.assetUnitName) &&
+                    assetManager.equals(that.assetManager) &&
+                    assetReserve.equals(that.assetReserve) &&
+                    assetFreeze.equals(that.assetFreeze) &&
+                    assetClawback.equals(that.assetClawback);
         }
 
         @JsonCreator
         private AssetParams(@JsonProperty("t") BigInteger assetTotal,
-            @JsonProperty("df") boolean assetDefaultFrozen,
-            @JsonProperty("un") String assetUnitName,
-            @JsonProperty("an") String assetName,
-            @JsonProperty("m") byte[] assetManager,
-            @JsonProperty("r") byte[] assetReserve,
-            @JsonProperty("f") byte[] assetFreeze,
-            @JsonProperty("c") byte[] assetClawback) {
+                @JsonProperty("df") boolean assetDefaultFrozen,
+                @JsonProperty("un") String assetUnitName,
+                @JsonProperty("an") String assetName,
+                @JsonProperty("m") byte[] assetManager,
+                @JsonProperty("r") byte[] assetReserve,
+                @JsonProperty("f") byte[] assetFreeze,
+                @JsonProperty("c") byte[] assetClawback) {
             this(assetTotal, assetDefaultFrozen, assetUnitName, assetName, new Address(assetManager), new Address(assetReserve), new Address(assetFreeze), new Address(assetClawback));
         }
     }
@@ -411,13 +685,13 @@ public class Transaction implements Serializable {
             if (o == null || getClass() != o.getClass()) return false;
             AssetID that = (AssetID) o;
             return creator.equals(that.creator) &&
-                index.equals(that.index);
+                    index.equals(that.index);
         }
 
         @JsonCreator
         private AssetID(@JsonProperty("c") byte[] creator,
-            @JsonProperty("i") BigInteger index) {
-                this(new Address(creator), index);
+                @JsonProperty("i") BigInteger index) {
+            this(new Address(creator), index);
         }
     }
 

--- a/src/main/java/com/algorand/algosdk/util/SignatureUtils.java
+++ b/src/main/java/com/algorand/algosdk/util/SignatureUtils.java
@@ -1,0 +1,53 @@
+package com.algorand.algosdk.util;
+import com.algorand.algosdk.util.CryptoProvider;
+
+import java.security.*;
+
+/**
+ * Implements signature utilities such as signing and estimating signed transaction sizes. 
+ * Has no dependencies on algosdk packages.
+ **/
+public class SignatureUtils {
+    
+    private static final String SIGN_ALGO = "EdDSA";
+    private static final String KEY_ALGO = "Ed25519";
+    private static final int SK_SIZE = 32;
+    private static final int SK_SIZE_BITS = SK_SIZE * 8;
+
+    private static KeyPair dummyKeyPair;
+
+    public static KeyPair generateKeyPair(SecureRandom randomSrc) throws NoSuchAlgorithmException {
+	CryptoProvider.setupIfNeeded();
+	KeyPairGenerator gen = KeyPairGenerator.getInstance(KEY_ALGO);
+	if (randomSrc != null) {
+	    gen.initialize(SK_SIZE_BITS, randomSrc);
+	}
+	return gen.generateKeyPair();
+    }
+    
+    public static KeyPair getDummyPrivateKey() throws NoSuchAlgorithmException {
+        if (null == dummyKeyPair) {
+            dummyKeyPair = generateKeyPair(null);
+        }
+        return dummyKeyPair;
+    }
+    /**
+     * Sign the given bytes, and wrap in Signature.
+     * @param bytes the data to sign
+     * @return a signature
+     * @throws NoSuchAlgorithmException 
+     */
+    public static byte[] rawSignBytes(byte[] bytes, PrivateKey pKey) throws NoSuchAlgorithmException {
+	
+	try {
+            CryptoProvider.setupIfNeeded();
+            java.security.Signature signer = java.security.Signature.getInstance(SIGN_ALGO);
+            signer.initSign(pKey);
+            signer.update(bytes);
+            byte[] sigRaw = signer.sign();
+            return sigRaw;
+        } catch (InvalidKeyException|SignatureException e) {
+            throw new RuntimeException("unexpected behavior", e);
+        }
+    }
+}

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.transaction;
 
-import com.algorand.algosdk.account.Account;
 import com.algorand.algosdk.crypto.Address;
 import com.algorand.algosdk.crypto.Digest;
 import com.algorand.algosdk.util.Encoder;
@@ -67,7 +66,7 @@ public class TestTransaction {
         Address clawback = addr;
 
         Transaction tx = new Transaction(sender, BigInteger.valueOf(10), BigInteger.valueOf(322575), BigInteger.valueOf(323575), null, "", new Digest(gh), creator, BigInteger.valueOf(1234), manager, reserve, freeze, clawback);
-        tx = Account.transactionWithSuggestedFeePerByte(tx, BigInteger.valueOf(10));
+        tx.setFeeWithSuggestedFeePerByte(BigInteger.valueOf(10));
 
         byte[] outBytes = Encoder.encodeToMsgPack(tx);
         byte[] golden = Encoder.decodeFromBase64("iKRhcGFyhKFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRjYWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpzQTSo2ZlZc0OzqJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhY2Zn");


### PR DESCRIPTION
Moving signing operations from Account to Transaction and SignatureUtils

Account.java depends on Transaction.java
Many of the signing operations are in Account.java
Given the dependency direction, Transaction cannot utilize the siging operations in Account.
Moving the siging operations to Transaction, so that both Transaction and Account can use them.
Since some of the siging operations need the account, factored out the core siging operations to utils.SigingUtils.
