### PR TITLE
Refactoring code in Transaction and Account.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: java
 
+before_script:
+  - echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+  - curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get install bazel -y
+
 install:
   - curl https://raw.githubusercontent.com/algorand/algorand-sdk-testing/master/scripts/sdkupdate.sh -o ~/sdkupdate.sh
   - chmod +x ~/sdkupdate.sh
 
 script:
   - mvn test -q
+  - bazel test //... --incompatible_depset_is_not_iterable=false
   - ~/sdkupdate.sh --java

--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -10,8 +10,8 @@ import com.algorand.algosdk.mnemonic.Mnemonic;
 import com.algorand.algosdk.transaction.SignedTransaction;
 import com.algorand.algosdk.transaction.Transaction;
 import com.algorand.algosdk.util.CryptoProvider;
-import com.algorand.algosdk.util.Digester;
 import com.algorand.algosdk.util.Encoder;
+import com.algorand.algosdk.util.SignatureUtils;
 
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1OctetString;
@@ -29,16 +29,10 @@ import java.util.Arrays;
 public class Account {
     private final KeyPair privateKeyPair;
     private final Address address;
-    private static final String KEY_ALGO = "Ed25519";
-    private static final String SIGN_ALGO = "EdDSA";
     private static final int PK_SIZE = 32;
     private static final int PK_X509_PREFIX_LENGTH = 12; // Ed25519 specific
-    private static final int SK_SIZE = 32;
-    private static final int SK_SIZE_BITS = SK_SIZE * 8;
-    private static final byte[] TX_SIGN_PREFIX = ("TX").getBytes(StandardCharsets.UTF_8);
     private static final byte[] BID_SIGN_PREFIX = ("aB").getBytes(StandardCharsets.UTF_8);
-    private static final byte[] BYTES_SIGN_PREFIX = ("MX").getBytes(StandardCharsets.UTF_8);
-    private static final BigInteger MIN_TX_FEE_UALGOS = BigInteger.valueOf(1000);
+    private static final byte[] BYTES_SIGN_PREFIX = ("MX").getBytes(StandardCharsets.UTF_8);    
 
     /**
      * Account creates a new, random account.
@@ -59,12 +53,7 @@ public class Account {
 
     // randomSrc can be null, in which case system default is used
     private Account(SecureRandom randomSrc) throws NoSuchAlgorithmException {
-        CryptoProvider.setupIfNeeded();
-        KeyPairGenerator gen = KeyPairGenerator.getInstance(KEY_ALGO);
-        if (randomSrc != null) {
-            gen.initialize(SK_SIZE_BITS, randomSrc);
-        }
-        this.privateKeyPair = gen.generateKeyPair();
+ 	this.privateKeyPair = SignatureUtils.generateKeyPair(randomSrc);
         // now, convert public key to an address
         byte[] raw = this.getClearTextPublicKey();
         this.address = new Address(Arrays.copyOf(raw, raw.length));
@@ -121,19 +110,7 @@ public class Account {
      * @throws NoSuchAlgorithmException if signing algorithm could not be found
      */
     public SignedTransaction signTransaction(Transaction tx) throws NoSuchAlgorithmException {
-        try {
-            byte[] encodedTx = Encoder.encodeToMsgPack(tx);
-            // prepend hashable prefix
-            byte[] prefixEncodedTx = new byte[encodedTx.length + TX_SIGN_PREFIX.length];
-            System.arraycopy(TX_SIGN_PREFIX, 0, prefixEncodedTx, 0, TX_SIGN_PREFIX.length);
-            System.arraycopy(encodedTx, 0, prefixEncodedTx, TX_SIGN_PREFIX.length, encodedTx.length);
-            // sign
-            Signature txSig = rawSignBytes(Arrays.copyOf(prefixEncodedTx, prefixEncodedTx.length));
-            String txID = Encoder.encodeToBase32StripPad(Digester.digest(prefixEncodedTx));
-            return new SignedTransaction(tx, txSig, txID);
-        } catch (IOException e) {
-            throw new RuntimeException("unexpected behavior", e);
-        }
+        return (tx.signTransaction(this.privateKeyPair.getPrivate()));
     }
 
     /**
@@ -145,7 +122,7 @@ public class Account {
     public SignedTransaction signTransactionBytes(byte[] bytes) throws NoSuchAlgorithmException, IOException {
         try {
             Transaction tx = Encoder.decodeFromMsgPack(bytes, Transaction.class);
-            return this.signTransaction(tx);
+            return tx.signTransaction(this.privateKeyPair.getPrivate());
         } catch (IOException e) {
             throw new IOException("could not decode transaction", e);
         }
@@ -159,8 +136,8 @@ public class Account {
      * @throws NoSuchAlgorithmException crypto provider not found
      */
     public SignedTransaction signTransactionWithFeePerByte(Transaction tx, BigInteger feePerByte) throws NoSuchAlgorithmException {
-        Transaction feeTx = transactionWithSuggestedFeePerByte(tx, feePerByte);
-        return this.signTransaction(feeTx);
+        tx.setFeeWithSuggestedFeePerByte(feePerByte);
+        return this.signTransaction(tx);
     }
 
     /**
@@ -189,11 +166,13 @@ public class Account {
      * @param suggestedFeePerByte suggestedFee given by network
      * @return transaction with proper fee set
      * @throws NoSuchAlgorithmException could not estimate tx encoded size.
+     * @deprecated replaced by {@link #Transaction.setFeeWithSuggestedFeePerByte}
      */
+    @Deprecated  
     static public Transaction transactionWithSuggestedFeePerByte(Transaction copyTx, BigInteger suggestedFeePerByte) throws NoSuchAlgorithmException{
         BigInteger newFee = suggestedFeePerByte.multiply(estimatedEncodedSize(copyTx));
-        if (newFee.compareTo(MIN_TX_FEE_UALGOS) < 0) {
-            newFee = MIN_TX_FEE_UALGOS;
+        if (newFee.compareTo(Transaction.MIN_TX_FEE_UALGOS) < 0) {
+            newFee = Transaction.MIN_TX_FEE_UALGOS;
         }
         switch (copyTx.type) {
             case Payment:
@@ -232,16 +211,7 @@ public class Account {
      * @return a signature
      */
     private Signature rawSignBytes(byte[] bytes) throws NoSuchAlgorithmException {
-        try {
-            CryptoProvider.setupIfNeeded();
-            java.security.Signature signer = java.security.Signature.getInstance(SIGN_ALGO);
-            signer.initSign(this.privateKeyPair.getPrivate());
-            signer.update(bytes);
-            byte[] sigRaw = signer.sign();
-            return new Signature(sigRaw);
-        } catch (InvalidKeyException|SignatureException e) {
-            throw new RuntimeException("unexpected behavior", e);
-        }
+        return new Signature(SignatureUtils.rawSignBytes(bytes, this.privateKeyPair.getPrivate()));
     }
 
     /**

--- a/src/main/java/com/algorand/algosdk/algod/client/ApiException.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ApiException.java
@@ -33,7 +33,7 @@ public class ApiException extends Exception {
     }
 
     public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        super(message, throwable);
+        super(message + " : " + responseBody, throwable);
         this.code = code;
         this.responseHeaders = responseHeaders;
         this.responseBody = responseBody;

--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -4,11 +4,19 @@ package com.algorand.algosdk.transaction;
 import com.algorand.algosdk.crypto.Address;
 import com.algorand.algosdk.crypto.Digest;
 import com.algorand.algosdk.crypto.ParticipationPublicKey;
+import com.algorand.algosdk.crypto.Signature;
 import com.algorand.algosdk.crypto.VRFPublicKey;
+import com.algorand.algosdk.util.Digester;
+import com.algorand.algosdk.util.Encoder;
+import com.algorand.algosdk.util.SignatureUtils;
 import com.fasterxml.jackson.annotation.*;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.util.Arrays;
 
 /**
@@ -18,12 +26,16 @@ import java.util.Arrays;
 @JsonPropertyOrder(alphabetic=true)
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class Transaction implements Serializable {
+
+    private static final byte[] TX_SIGN_PREFIX = ("TX").getBytes(StandardCharsets.UTF_8);
+    public static final BigInteger MIN_TX_FEE_UALGOS = BigInteger.valueOf(1000);
+
     @JsonProperty("type")
     public Type type = Type.Default;
 
     // Instead of embedding POJOs and using JsonUnwrapped, we explicitly export inner fields. This circumvents our encoders'
     // inability to sort child fields.
-    /* header fields */
+    /* header fields ***********************************************************/
     @JsonProperty("snd")
     public Address sender = new Address();
     @JsonProperty("fee")
@@ -39,7 +51,7 @@ public class Transaction implements Serializable {
     @JsonProperty("gh")
     public Digest genesisHash = new Digest();
 
-    /* payment fields */
+    /* payment fields  *********************************************************/
     @JsonProperty("amt")
     public BigInteger amount = BigInteger.valueOf(0);
     @JsonProperty("rcv")
@@ -47,28 +59,60 @@ public class Transaction implements Serializable {
     @JsonProperty("close")
     public Address closeRemainderTo = new Address(); // can be null, optional
 
-    /* keyreg fields */
+    /* keyreg fields ***********************************************************/
     // VotePK is the participation public key used in key registration transactions
     @JsonProperty("votekey")
     public ParticipationPublicKey votePK = new ParticipationPublicKey();
+
     // selectionPK is the VRF public key used in key registration transactions
     @JsonProperty("selkey")
     public VRFPublicKey selectionPK = new VRFPublicKey();
     // voteFirst is the first round this keyreg tx is valid for
     @JsonProperty("votefst")
     public BigInteger voteFirst = BigInteger.valueOf(0);
+
     // voteLast is the last round this keyreg tx is valid for
     @JsonProperty("votelst")
     public BigInteger voteLast = BigInteger.valueOf(0);
+
     // voteKeyDilution
+
     @JsonProperty("votekd")
-    public BigInteger voteKeyDilution = BigInteger.valueOf(0);
-    
-    /* asset creation and config fields */
+    public BigInteger voteKeyDilution= BigInteger.valueOf(0);
+
+    /* asset creation and configuration fields *********************************/
     @JsonProperty("apar")
     public AssetParams assetParams = new AssetParams();
     @JsonProperty("caid")
     public AssetID assetID = new AssetID();
+
+    /* asset transfer fields ***************************************************/
+    @JsonProperty("xaid")
+    public AssetID xferAsset = new AssetID();
+
+    // The amount of asset to transfer. A zero amount transferred to self
+    // allocates that asset in the account's Assets map.
+    @JsonProperty("aamt")
+    public BigInteger assetAmount = BigInteger.valueOf(0);
+
+    // The sender of the transfer.  If this is not a zero value, the real
+    // transaction sender must be the Clawback address from the AssetParams. If
+    // this is the zero value, the asset is sent from the transaction's Sender.
+    @JsonProperty("asnd")
+    public Address assetSender = new Address();
+
+    // The receiver of the transfer.
+    @JsonProperty("arcv")
+    public Address assetReceiver = new Address();
+
+    // Indicates that the asset should be removed from the account's Assets map,
+    // and specifies where the remaining asset holdings should be transferred.
+    // It's always valid to transfer remaining asset holdings to the AssetID
+    // account.
+    @JsonProperty("aclose")
+    public Address assetCloseTo = new Address();
+
+
     /**
      * Create a payment transaction
      * @param fromAddr source address
@@ -78,15 +122,219 @@ public class Transaction implements Serializable {
      * @param firstRound first valid round
      * @param lastRound last valid round
      */
-    public Transaction(Address fromAddr, Address toAddr, BigInteger fee, BigInteger amount, BigInteger firstRound,
-                       BigInteger lastRound) {
-        this(fromAddr, fee, firstRound, lastRound, null, amount, toAddr, "", new Digest());
+    public Transaction(
+            Address fromAddr, 
+            Address toAddr, 
+            BigInteger fee, 
+            BigInteger amount, 
+            BigInteger firstRound,
+            BigInteger lastRound) {
+
+        this.type = Type.Payment;
+        if (fromAddr != null) this.sender = fromAddr;
+        if (fee != null) this.fee = fee;
+        if (firstRound != null) this.firstValid = firstRound;
+        if (lastRound != null) this.lastValid = lastRound;
+        if (amount != null) this.amount = amount;
+        if (toAddr != null) this.receiver = toAddr;
     }
 
-    public Transaction(Address fromAddr, Address toAddr, BigInteger fee, BigInteger amount, BigInteger firstRound,
-                       BigInteger lastRound,
-                       String genesisID, Digest genesisHash) {
-        this(fromAddr, fee, firstRound, lastRound, null, amount, toAddr, genesisID, genesisHash);
+
+    /**
+     * Sign a transaction with pKey
+     * @param pKey the key to sign with
+     * @return a signed transaction
+     * @throws NoSuchAlgorithmException if signing algorithm could not be found
+     */
+    public SignedTransaction signTransaction(PrivateKey pKey) throws NoSuchAlgorithmException {
+        try {
+            byte[] encodedTx = Encoder.encodeToMsgPack(this);
+            String delme = Encoder.encodeToJson(this);
+            // prepend hashable prefix
+            byte[] prefixEncodedTx = new byte[encodedTx.length + TX_SIGN_PREFIX.length];
+            System.arraycopy(TX_SIGN_PREFIX, 0, prefixEncodedTx, 0, TX_SIGN_PREFIX.length);
+            System.arraycopy(encodedTx, 0, prefixEncodedTx, TX_SIGN_PREFIX.length, encodedTx.length);
+            // sign
+            Signature txSig = new Signature(
+                    SignatureUtils.rawSignBytes(
+                            Arrays.copyOf(
+                                    prefixEncodedTx,
+                                    prefixEncodedTx.length),
+                            pKey));
+            String txID = Encoder.encodeToBase32StripPad(Digester.digest(prefixEncodedTx));
+            return new SignedTransaction(this, txSig, txID);
+        } catch (IOException e) {
+            throw new RuntimeException("unexpected behavior", e);
+        }
+    }
+
+    /**
+     * Populate the fee with suggestedFeePerByte * estimateTxSize.
+     * @param suggestedFeePerByte suggestedFee given by network
+     * @throws NoSuchAlgorithmException could not estimate tx encoded size.
+     */
+    public void setFeeWithSuggestedFeePerByte(BigInteger suggestedFeePerByte) throws NoSuchAlgorithmException{
+        BigInteger newFee = suggestedFeePerByte.multiply(this.estimatedEncodedSize());
+        this.setFee(newFee);
+    }
+
+    /**
+     * EstimateEncodedSize returns the estimated encoded size of the transaction including the signature.
+     * This function is used for calculating the fee from suggested fee per byte.
+     * @return an estimated byte size for the transaction.
+     */
+    public BigInteger estimatedEncodedSize() throws NoSuchAlgorithmException {
+        try {
+            return BigInteger.valueOf(
+                    Encoder.encodeToMsgPack(
+                            this.signTransaction(
+                                    SignatureUtils.getDummyPrivateKey().getPrivate())).length);
+        } catch (IOException e) {
+            throw new RuntimeException("unexpected behavior", e);
+        }
+    }
+
+    /**
+     * Set the transaction fee value.
+     * @param newFee the fee suggested for the transaction. If the
+     * newFee is less than the minimum transaction fee, it is replaced
+     * by the minimum fee. 
+     **/
+    public void setFee(BigInteger newFee) {
+        if (newFee.compareTo(MIN_TX_FEE_UALGOS) < 0) {
+            newFee = MIN_TX_FEE_UALGOS;
+        }
+        fee = newFee;
+    }
+
+    /**
+     * Creates a tx to mark the account as willing to accept the asset.
+     * @param acceptingAccount is a checksummed, human-readable address that
+     * will accept receiving the asset.
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    public static Transaction acceptAssetTransaction(Address acceptingAccount, //AssetTransaction
+            BigInteger flatFee,
+            BigInteger firstRound,
+            BigInteger lastRound,
+            byte [] note,
+            String genesisID,
+            Digest genesisHash,
+            Address assetCreator,
+            BigInteger assetIndex) {
+
+        Transaction tx = assetTransferTransaction(
+                acceptingAccount,
+                acceptingAccount,
+                new Address(),
+                BigInteger.valueOf(0),
+                flatFee,
+                firstRound,
+                lastRound,
+                note,
+                genesisID,
+                genesisHash,
+                assetCreator,
+                assetIndex);
+
+        return tx;
+    }
+
+    /**
+     * Creates a tx for sending some asset from an asset holder to another user.
+     *  The asset receiver must have marked itself as willing to accept the
+     *  asset.
+     * @param assetSender is a checksummed, human-readable address that will
+     * send the transaction and assets
+     * @param assetReceiver is a checksummed, human-readable address what will
+     * receive the assets
+     * @param assetCloseTo is a checksummed, human-readable address that
+     * behaves as a close-to address for the asset transaction; the remaining
+     * assets not sent to assetReceiver will be sent to assetCloseTo. Leave
+     * blank for no close-to behavior.
+     * @param assetAmount is the number of assets to send
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    public static Transaction assetTransferTransaction(// AssetTransaction
+            Address assetSender,
+            Address assetReceiver,
+            Address assetCloseTo,
+            BigInteger assetAmount,
+            BigInteger flatFee,
+            BigInteger firstRound,
+            BigInteger lastRound,
+            byte [] note,
+            String genesisID,
+            Digest genesisHash,
+            Address assetCreator,
+            BigInteger assetIndex) {
+
+        Transaction tx = new Transaction(
+                flatFee,    // fee
+                firstRound, // fv
+                lastRound, // lv
+                note, //note
+                genesisID, // gen
+                genesisHash, // gh
+                assetCreator, // c
+                assetIndex); // i
+
+        tx.assetReceiver = assetReceiver; //arcv
+        tx.assetCloseTo = assetCloseTo; // aclose
+        tx.assetAmount = assetAmount; // aamt
+        tx.sender = assetSender; // snd
+
+        return tx;
+    }
+
+
+    /**
+     * Build an unsigned transaction
+     * @param fromAddr
+     * @param toAddr
+     * @param fee
+     * @param amount
+     * @param firstRound
+     * @param lastRound
+     * @param genesisID
+     * @param genesisHash
+     */
+    public Transaction(
+            Address fromAddr,
+            Address toAddr,
+            BigInteger fee,
+            BigInteger amount,
+            BigInteger firstRound,
+            BigInteger lastRound,
+            String genesisID,
+            Digest genesisHash) {
+        if (type != null) this.type = Type.Payment;
+        if (sender != null) this.sender = fromAddr;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstRound;
+        if (lastValid != null) this.lastValid = lastRound;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        if (amount != null) this.amount = amount;
+        if (toAddr != null) this.receiver = toAddr;
     }
 
     /**
@@ -99,24 +347,95 @@ public class Transaction implements Serializable {
      * @param genesisID genesis id
      * @param genesisHash genesis hash
      */
-    public Transaction(Address fromAddr, Address toAddr, long amount, long firstRound, long lastRound,
-                       String genesisID, Digest genesisHash) {
-        this(fromAddr, BigInteger.valueOf(0), BigInteger.valueOf(firstRound), BigInteger.valueOf(lastRound), null, BigInteger.valueOf(amount), toAddr, genesisID, genesisHash);
+    public Transaction(
+            Address fromAddr,
+            Address toAddr,
+            long amount,
+            long firstRound,
+            long lastRound,
+            String genesisID,
+            Digest genesisHash) {
+
+        if (type != null) this.type = Type.Payment;
+        if (sender != null) this.sender = fromAddr;
+        if (firstValid != null) this.firstValid = BigInteger.valueOf(firstRound);
+        if (lastValid != null) this.lastValid = BigInteger.valueOf(lastRound);
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        this.amount = BigInteger.valueOf(amount);
+        if (toAddr != null) this.receiver = toAddr;
     }
 
-    public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       BigInteger amount, Address receiver, String genesisID, Digest genesisHash) {
-        this(sender, fee, firstValid, lastValid, note, genesisID, genesisHash, amount, receiver, new Address());
-    }
+    public Transaction(
+            Address sender,
+            BigInteger fee,
+            BigInteger firstValid,
+            BigInteger lastValid,
+            byte[] note,
+            BigInteger amount,
+            Address receiver,
+            String genesisID,
+            Digest genesisHash) {
 
-    public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note, String genesisID, Digest genesisHash,
-                       BigInteger amount, Address receiver, Address closeRemainderTo) {
-        this(Type.Payment, sender, fee, firstValid, lastValid, note, genesisID, genesisHash, amount, receiver, closeRemainderTo,
-                new ParticipationPublicKey(), new VRFPublicKey(), BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(), new AssetParams());
+        if (type != null) this.type = Type.Payment;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+
+        if (amount != null) this.amount = amount;
+        if (receiver != null) this.receiver = receiver;
     }
 
     /**
-     * Create a key registration transaction. No field can be null except the note field.
+     * Create a payment transaction
+     * @param sender
+     * @param fee
+     * @param firstValid
+     * @param lastValid
+     * @param note
+     * @param genesisID
+     * @param genesisHash
+     * @param amount
+     * @param receiver
+     * @param closeRemainderTo
+     */
+    public Transaction(
+            Address sender,
+            BigInteger fee,
+            BigInteger firstValid,
+            BigInteger lastValid,
+            byte[] note,
+
+            String genesisID,
+            Digest genesisHash,
+
+            BigInteger amount,
+            Address receiver,
+            Address closeRemainderTo) {
+
+        if (type != null) this.type = Type.Payment;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+
+        if (amount != null) this.amount = amount;
+        if (receiver != null) this.receiver = receiver;
+        if (closeRemainderTo != null) this.closeRemainderTo = closeRemainderTo;
+    }
+
+    /**
+     * Create a key registration transaction.
+     * No field can be null except the note field.
      * @param sender source address
      * @param fee transaction fee
      * @param firstValid first valid round
@@ -128,18 +447,43 @@ public class Transaction implements Serializable {
      * @param voteLast key reg valid last round
      * @param voteKeyDilution key reg dilution
      */
-    public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       String genesisID, Digest genesisHash,
-                       ParticipationPublicKey votePK, VRFPublicKey vrfPK,
-                       BigInteger voteFirst, BigInteger voteLast, BigInteger voteKeyDilution) {
-        // populate with default values which will be ignored...
-        this(Type.KeyRegistration, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), votePK, vrfPK, voteFirst, voteLast, 
-                voteKeyDilution, new AssetID(), new AssetParams());
+    public Transaction(Address sender,
+            BigInteger fee,
+            BigInteger firstValid,
+            BigInteger lastValid,
+            byte[] note,
+
+            String genesisID,
+            Digest genesisHash,
+
+            ParticipationPublicKey votePK,
+            VRFPublicKey vrfPK,
+
+            BigInteger voteFirst,
+            BigInteger voteLast,
+            BigInteger voteKeyDilution) {
+
+        if (type != null) this.type = Type.KeyRegistration;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+
+        if (votePK != null) this.votePK = votePK;
+        if (vrfPK != null) this.selectionPK = vrfPK;
+
+        if (voteFirst != null) this.voteFirst = voteFirst;
+        if (voteLast != null) this.voteLast = voteLast;
+        if (voteKeyDilution != null) this.voteKeyDilution = voteKeyDilution;
     }
 
     /**
-     * Create an asset creation transaction. Note can be null. manager, reserve, freeze, and clawback can be zeroed.
+     * Create an asset creation transaction.
+     * Note can be null. manager, reserve, freeze, and clawback can be zeroed.
      * @param sender source address
      * @param fee transaction fee
      * @param firstValid first valid round
@@ -156,17 +500,49 @@ public class Transaction implements Serializable {
      * @param freeze account which can freeze or unfreeze holder accounts
      * @param clawback account which can issue clawbacks against holder accounts
      */
-    public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       String genesisID, Digest genesisHash, BigInteger assetTotal, boolean defaultFrozen,
-                       String assetUnitName, String assetName, Address manager, Address reserve, Address freeze, Address clawback) {
-        // populate ignored values with default or null values
-        this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(), 
-                new AssetParams(assetTotal, defaultFrozen, assetUnitName, assetName, manager, reserve, freeze, clawback));
+    public Transaction(
+            Address sender,
+            BigInteger fee,
+            BigInteger firstValid,
+            BigInteger lastValid,
+            byte[] note,
+
+            String genesisID,
+            Digest genesisHash,
+
+            BigInteger assetTotal,
+            boolean defaultFrozen,
+            String assetUnitName,
+            String assetName,
+            Address manager,
+            Address reserve,
+            Address freeze,
+            Address clawback) {
+
+        if (type != null) this.type = Type.AssetConfig;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+
+        new AssetParams(assetTotal,
+                defaultFrozen,
+                assetUnitName,
+                assetName,
+                manager,
+                reserve,
+                freeze,
+                clawback);
     }
 
     /**
-     * Create an asset configuration transaction. Note can be null. manager, reserve, freeze, and clawback can be zeroed.
+     * Create an asset configuration transaction.
+     * assetID and assetParams passed in as object fields
+     * Note can be null. manager, reserve, freeze, and clawback can be zeroed.
      * @param sender source address
      * @param fee transaction fee
      * @param firstValid first valid round
@@ -183,65 +559,208 @@ public class Transaction implements Serializable {
      * @param freeze account which can freeze or unfreeze holder accounts
      * @param clawback account which can issue clawbacks against holder accounts
      */
-    public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       String genesisID, Digest genesisHash, Address creator, BigInteger index,
-                    Address manager, Address reserve, Address freeze, Address clawback) {
-        // populate ignored values with default or null values
-        this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(creator, index), 
-                new AssetParams(BigInteger.valueOf(0), false, "", "", manager, reserve, freeze, clawback));
+    public Transaction(Address sender,
+            BigInteger fee,
+            BigInteger firstValid,
+            BigInteger lastValid,
+            byte[] note,
+
+            String genesisID,
+            Digest genesisHash,
+            Address creator,
+            BigInteger index,
+            Address manager,
+            Address reserve,
+            Address freeze,
+            Address clawback) {
+        this(
+                sender,
+                fee,
+                firstValid,
+                lastValid,
+                note,
+                genesisID,
+                genesisHash,
+                new AssetID(
+                        creator,
+                        index),
+                new AssetParams(
+                        BigInteger.valueOf(0),
+                        false,
+                        "",
+                        "",
+                        manager,
+                        reserve,
+                        freeze,
+                        clawback));
     }
 
-    public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
-                       String genesisID, Digest genesisHash, AssetID assetID, AssetParams assetParams) {
-        // populate ignored values with default or null values
-        this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), assetID, assetParams);
+
+    /**
+     * Create an asset configuration transaction.
+     * assetID and assetParams passed in as objects
+     * Note can be null. manager, reserve, freeze, and clawback can be zeroed.
+     * @param sender source address
+     * @param fee transaction fee
+     * @param firstValid first valid round
+     * @param lastValid last valid round
+     * @param note optional note field (can be null)
+     * @param genesisID
+     * @param genesisHash
+     * @param assetID
+     * @param assetParams
+     */
+    public Transaction(Address sender,
+            BigInteger fee,
+            BigInteger firstValid,
+            BigInteger lastValid,
+            byte[] note,
+            String genesisID,
+            Digest genesisHash,
+            AssetID assetID,
+            AssetParams assetParams) {
+        this.type = Type.AssetConfig;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        if (assetID != null) this.assetID = assetID;
+        if (assetParams != null) this.assetParams = assetParams;
+    }
+
+    /**
+     * Base constructor with flat fee for asset xfer transactions.
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    private Transaction(// Asset xfer transaction
+            BigInteger flatFee,
+            BigInteger firstRound,
+            BigInteger lastRound,
+            byte [] note,
+            String genesisID,
+            Digest genesisHash,
+            Address assetCreator,
+            BigInteger assetIndex) {
+
+        this.type = Type.AssetTransfer;
+        if (flatFee != null) this.fee = flatFee;
+        if (firstRound != null) this.firstValid = firstRound;
+        if (lastRound != null) this.lastValid = lastRound;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        if (assetCreator != null) this.xferAsset = new AssetID(assetCreator,
+                assetIndex);
+
     }
 
     // workaround for nested JsonValue classes
     @JsonCreator
     private Transaction(@JsonProperty("type") Type type,
-                        @JsonProperty("snd") byte[] sender,
-                        @JsonProperty("fee") BigInteger fee,
-                        @JsonProperty("fv") BigInteger firstValid,
-                        @JsonProperty("lv") BigInteger lastValid,
-                        @JsonProperty("note") byte[] note,
-                        @JsonProperty("gen") String genesisID,
-                        @JsonProperty("gh") byte[] genesisHash,
-                        @JsonProperty("amt") BigInteger amount,
-                        @JsonProperty("rcv") byte[] receiver,
-                        @JsonProperty("close") byte[] closeRemainderTo,
-                        @JsonProperty("votekey") byte[] votePK,
-                        @JsonProperty("selkey") byte[] vrfPK,
-                        @JsonProperty("votefst") BigInteger voteFirst,
-                        @JsonProperty("votelst") BigInteger voteLast,
-                        @JsonProperty("votekd") BigInteger voteKeyDilution,
-                        @JsonProperty("caid") AssetID assetID,
-                        @JsonProperty("apar") AssetParams assetParams) {
-        this(type, new Address(sender), fee, firstValid, lastValid, note, genesisID, new Digest(genesisHash), amount,
-                new Address(receiver), new Address(closeRemainderTo), new ParticipationPublicKey(votePK), new VRFPublicKey(vrfPK),
-                voteFirst, voteLast, voteKeyDilution, assetID, assetParams);
+            //header fields
+            @JsonProperty("snd") byte[] sender,
+            @JsonProperty("fee") BigInteger fee,
+            @JsonProperty("fv") BigInteger firstValid,
+            @JsonProperty("lv") BigInteger lastValid,
+            @JsonProperty("note") byte[] note,
+            @JsonProperty("gen") String genesisID,
+            @JsonProperty("gh") byte[] genesisHash,
+            // payment fields
+            @JsonProperty("amt") BigInteger amount,
+            @JsonProperty("rcv") byte[] receiver,
+            @JsonProperty("close") byte[] closeRemainderTo,
+            // keyreg fields
+            @JsonProperty("votekey") byte[] votePK,
+            @JsonProperty("selkey") byte[] vrfPK,
+            @JsonProperty("votefst") BigInteger voteFirst,
+            @JsonProperty("votelst") BigInteger voteLast,
+            @JsonProperty("votekd") BigInteger voteKeyDilution,
+            // asset creation and configuration
+            @JsonProperty("caid") AssetID assetID,
+            @JsonProperty("apar") AssetParams assetParams,
+            // Asset xfer transaction fields
+            @JsonProperty("xaid") AssetID xferAsset,
+            @JsonProperty("aamt") BigInteger assetAmount,
+            @JsonProperty("asnd") byte[] assetSender,
+            @JsonProperty("arcv") byte[] assetReceiver,
+            @JsonProperty("aclose") byte[] assetCloseTo) {
+        this(
+                type,
+                //header fields
+                new Address(sender),
+                fee,
+                firstValid,
+                lastValid,
+                note,
+                genesisID,
+                new Digest(genesisHash),
+                // payment fields
+                amount,
+                new Address(receiver),
+                new Address(closeRemainderTo),
+                // keyreg fields
+                new ParticipationPublicKey(votePK),
+                new VRFPublicKey(vrfPK),
+                voteFirst,
+                voteLast,
+                voteKeyDilution,
+                // asset creation and configuration
+                assetParams,
+                assetID,
+                // asset transfer fields
+                xferAsset,
+                assetAmount,
+                new Address(assetSender),
+                new Address(assetReceiver),
+                new Address(assetCloseTo));
     }
 
-    private Transaction(Type type,
-                        Address sender,
-                        BigInteger fee,
-                        BigInteger firstValid,
-                        BigInteger lastValid,
-                        byte[] note,
-                        String genesisID,
-                        Digest genesisHash,
-                        BigInteger amount,
-                        Address receiver,
-                        Address closeRemainderTo,
-                        ParticipationPublicKey votePK,
-                        VRFPublicKey vrfPK,
-                        BigInteger voteFirst,
-                        BigInteger voteLast,
-                        BigInteger voteKeyDilution,
-                        AssetID assetID,
-                        AssetParams assetParams) {
+    /**
+     * This is the private constructor which takes all the fields of Transaction
+     **/
+    private Transaction(
+            Type type,
+            //header fields
+            Address sender,
+            BigInteger fee,
+            BigInteger firstValid,
+            BigInteger lastValid,
+            byte[] note,
+            String genesisID,
+            Digest genesisHash,
+            // payment fields
+            BigInteger amount,
+            Address receiver,
+            Address closeRemainderTo,
+            // keyreg fields
+            ParticipationPublicKey votePK,
+            VRFPublicKey vrfPK,
+            BigInteger voteFirst,
+            BigInteger voteLast,
+            // voteKeyDilution
+            BigInteger voteKeyDilution,
+            // asset creation and configuration
+            AssetParams assetParams,
+            AssetID assetID,
+            // asset transfer fields
+            AssetID xferAsset,
+            BigInteger assetAmount,
+            Address assetSender,
+            Address assetReceiver,
+            Address assetCloseTo
+            ) {
         if (type != null) this.type = type;
         if (sender != null) this.sender = sender;
         if (fee != null) this.fee = fee;
@@ -260,6 +779,12 @@ public class Transaction implements Serializable {
         if (voteKeyDilution != null) this.voteKeyDilution = voteKeyDilution;
         if (assetParams != null) this.assetParams = assetParams;
         if (assetID != null) this.assetID = assetID;
+        if (xferAsset != null) this.xferAsset = xferAsset;
+        if (assetAmount != null) this.assetAmount = assetAmount;
+        if (assetSender != null) this.assetSender = assetSender;
+        if (assetReceiver != null) this.assetReceiver = assetReceiver;
+        if (assetCloseTo != null) this.assetCloseTo = assetCloseTo;
+
     }
 
     public Transaction() {
@@ -272,7 +797,8 @@ public class Transaction implements Serializable {
         Default(""),
         Payment("pay"),
         KeyRegistration("keyreg"),
-        AssetConfig("acfg");
+        AssetConfig("acfg"),
+        AssetTransfer("axfer");
 
         private final String value;
         private Type(String value) {
@@ -341,7 +867,7 @@ public class Transaction implements Serializable {
         // the address which has the ability to issue clawbacks against asset-holding accounts
         @JsonProperty("c")
         public Address assetClawback = new Address();
-        
+
         public AssetParams(BigInteger assetTotal, boolean defaultFrozen, String assetUnitName, String assetName, Address manager, Address reserve, Address freeze, Address clawback) {
             if(assetTotal != null) this.assetTotal = assetTotal;
             this.assetDefaultFrozen = defaultFrozen;

--- a/src/main/java/com/algorand/algosdk/util/SignatureUtils.java
+++ b/src/main/java/com/algorand/algosdk/util/SignatureUtils.java
@@ -1,0 +1,53 @@
+package com.algorand.algosdk.util;
+import com.algorand.algosdk.util.CryptoProvider;
+
+import java.security.*;
+
+/**
+ * Implements signature utilities such as signing and estimating signed transaction sizes. 
+ * Has no dependencies on algosdk packages.
+ **/
+public class SignatureUtils {
+    
+    private static final String SIGN_ALGO = "EdDSA";
+    private static final String KEY_ALGO = "Ed25519";
+    private static final int SK_SIZE = 32;
+    private static final int SK_SIZE_BITS = SK_SIZE * 8;
+
+    private static KeyPair dummyKeyPair;
+
+    public static KeyPair generateKeyPair(SecureRandom randomSrc) throws NoSuchAlgorithmException {
+	CryptoProvider.setupIfNeeded();
+	KeyPairGenerator gen = KeyPairGenerator.getInstance(KEY_ALGO);
+	if (randomSrc != null) {
+	    gen.initialize(SK_SIZE_BITS, randomSrc);
+	}
+	return gen.generateKeyPair();
+    }
+    
+    public static KeyPair getDummyPrivateKey() throws NoSuchAlgorithmException {
+        if (null == dummyKeyPair) {
+            dummyKeyPair = generateKeyPair(null);
+        }
+        return dummyKeyPair;
+    }
+    /**
+     * Sign the given bytes, and wrap in Signature.
+     * @param bytes the data to sign
+     * @return a signature
+     * @throws NoSuchAlgorithmException 
+     */
+    public static byte[] rawSignBytes(byte[] bytes, PrivateKey pKey) throws NoSuchAlgorithmException {
+	
+	try {
+            CryptoProvider.setupIfNeeded();
+            java.security.Signature signer = java.security.Signature.getInstance(SIGN_ALGO);
+            signer.initSign(pKey);
+            signer.update(bytes);
+            byte[] sigRaw = signer.sign();
+            return sigRaw;
+        } catch (InvalidKeyException|SignatureException e) {
+            throw new RuntimeException("unexpected behavior", e);
+        }
+    }
+}

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -3,6 +3,7 @@ package com.algorand.algosdk.transaction;
 import com.algorand.algosdk.account.Account;
 import com.algorand.algosdk.crypto.Address;
 import com.algorand.algosdk.crypto.Digest;
+import com.algorand.algosdk.mnemonic.Mnemonic;
 import com.algorand.algosdk.util.Encoder;
 import org.junit.Assert;
 import org.junit.Test;
@@ -67,7 +68,7 @@ public class TestTransaction {
         Address clawback = addr;
 
         Transaction tx = new Transaction(sender, BigInteger.valueOf(10), BigInteger.valueOf(322575), BigInteger.valueOf(323575), null, "", new Digest(gh), creator, BigInteger.valueOf(1234), manager, reserve, freeze, clawback);
-        tx = Account.transactionWithSuggestedFeePerByte(tx, BigInteger.valueOf(10));
+        tx.setFeeWithSuggestedFeePerByte(BigInteger.valueOf(10));
 
         byte[] outBytes = Encoder.encodeToMsgPack(tx);
         byte[] golden = Encoder.decodeFromBase64("iKRhcGFyhKFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRjYWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpzQTSo2ZlZc0OzqJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhY2Zn");
@@ -77,4 +78,140 @@ public class TestTransaction {
         Assert.assertEquals(tx, o);
     }
 
+    @Test
+    public void testMakeAssetAcceptanceTxn() throws Exception {
+
+        final String FROM_SK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred";
+        byte[] seed = Mnemonic.toKey(FROM_SK);
+        Account account = new Account(seed);
+
+        Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");
+        byte[] gh = Encoder.decodeFromBase64("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+        Address recipient = addr;
+        Address creator = addr;
+
+        BigInteger assetIndex = BigInteger.valueOf(1);
+        BigInteger firstValidRound = BigInteger.valueOf(322575);
+        BigInteger lastValidRound = BigInteger.valueOf(323575);
+
+        Transaction tx = Transaction.acceptAssetTransaction(
+                recipient,
+                BigInteger.valueOf(10),
+                firstValidRound,
+                lastValidRound,
+                null,
+                "",
+                new Digest(gh),
+                creator,
+                assetIndex);
+
+        tx.setFeeWithSuggestedFeePerByte(tx.fee);
+        byte[] outBytes = Encoder.encodeToMsgPack(tx);
+        Transaction o = Encoder.decodeFromMsgPack(outBytes, Transaction.class);
+        Assert.assertEquals(o,  tx);
+
+        /*  Example from: go-algorand-sdk/transaction/transaction_test.go
+         *  {
+         *     "sig:b64": "0u7LDECdsm6RA0vqlX3w09zsDTNih1eYrwuIbISB64HMi4opQXdEZnWwJfbu31CWfkyTR+cGJ1aR7T7e4oHKDw==",
+         *     "txn": {
+         *       "arcv:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *       "fee": 2670,
+         *       "fv": 322575,
+         *       "gh:b64": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+         *       "lv": 323575,
+         *       "snd:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *       "type": "axfer",
+         *       "xaid": {
+         *         "c:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *         "i": 1
+         *       }
+         *     }
+         *   }
+         */
+        SignedTransaction stx = account.signTransaction(tx);
+        byte[] signedOutBytes = Encoder.encodeToMsgPack(stx);
+        byte[] golden = Encoder.decodeFromBase64("gqNzaWfEQNLuywxAnbJukQNL6pV98NPc7A0zYodXmK8LiGyEgeuBzIuKKUF3RGZ1sCX27t9Qln5Mk0fnBidWke0+3uKByg+jdHhuiKRhcmN2xCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aNmZWXNCm6iZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWlYXhmZXKkeGFpZIKhY8QgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2haQE=");
+
+        SignedTransaction stxDecoded = Encoder.decodeFromMsgPack(signedOutBytes, SignedTransaction.class);
+        Assert.assertEquals(stx, stxDecoded);
+        Assert.assertArrayEquals(signedOutBytes, golden);
+    }
+
+
+    @Test
+    public void testMakeAssetTransferTxn() throws Exception {
+
+        final String FROM_SK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred";
+        byte[] seed = Mnemonic.toKey(FROM_SK);
+        Account account = new Account(seed);
+
+        Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");
+        byte[] gh = Encoder.decodeFromBase64("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+        Address sender = addr;
+        Address recipient = addr;
+        Address creator = addr;
+        Address closeAssetsTo = addr;
+
+        BigInteger assetIndex = BigInteger.valueOf(1);
+        BigInteger firstValidRound = BigInteger.valueOf(322575);
+        BigInteger lastValidRound = BigInteger.valueOf(323576);
+        BigInteger amountToSend = BigInteger.valueOf(1);
+
+        Transaction tx = Transaction.assetTransferTransaction(
+                sender,
+                recipient,
+                closeAssetsTo,
+                amountToSend,
+                BigInteger.valueOf(10),
+                firstValidRound,
+                lastValidRound,
+                null,
+                "",
+                new Digest(gh),
+                creator,
+                assetIndex);
+
+        tx.setFeeWithSuggestedFeePerByte(tx.fee);
+        byte[] outBytes = Encoder.encodeToMsgPack(tx);
+        Transaction o = Encoder.decodeFromMsgPack(outBytes, Transaction.class);
+        Assert.assertEquals(o,  tx);
+
+        /*
+         * Golden from: go-algorand-sdk/transaction/transaction_test.go
+         *{
+         *  "sig:b64": "aST0K284qefidTn3GY8ahm9i/7pMK7kH3k+DBD9jK3AT12vX316ESoCdJLQLZJo7hiEQECT4lU6LBmJGr/DWCA==",
+         *  "txn": {
+         *    "aamt": 1,
+         *    "aclose:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *    "arcv:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *    "fee": 3140,
+         *    "fv": 322575,
+         *    "gh:b64": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+         *    "lv": 323576,
+         *    "snd:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *    "type": "axfer",
+         *    "xaid": {
+         *      "c:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *      "i": 1
+         *    }
+         *  }
+         *}
+         *
+         * goal command:
+         * goal asset send  -a 1
+         * --from     BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4
+         * --to       BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4
+         * --creator  BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4
+         * --close-to BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4
+         * --assetid 1 -s
+         */
+
+        SignedTransaction stx = account.signTransaction(tx);
+        byte[] signedOutBytes = Encoder.encodeToMsgPack(stx);
+        byte[] golden = Encoder.decodeFromBase64("gqNzaWfEQGkk9CtvOKnn4nU59xmPGoZvYv+6TCu5B95PgwQ/YytwE9dr199ehEqAnSS0C2SaO4YhEBAk+JVOiwZiRq/w1gijdHhuiqRhYW10AaZhY2xvc2XEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pGFyY3bEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9o2ZlZc0MRKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/4o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaVheGZlcqR4YWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAQ==");
+        SignedTransaction stxDecoded = Encoder.decodeFromMsgPack(signedOutBytes, SignedTransaction.class);
+
+        Assert.assertEquals(stx, stxDecoded);
+        Assert.assertArrayEquals(signedOutBytes, golden);
+    }
 }


### PR DESCRIPTION
1)
Account.java depends on Transaction.java
Many of the signing operations are in Account.java
Given the dependency direction, Transaction cannot utilize the signing operations in Account.
Moving the signing operations to Transaction, so that both Transaction and Account can use them.
Since some of the signing operations need the account, factored out the core signing operations to utils.SignatureUtils.

2)
Added SignatureUtils.getDummyPrivateKey utility to generate a private key and cache it.
This is used for signing transactions for the purpose of measuring the encoding size to determine the fee.
Note that a new key is not generated every time when getDummyPrivateKey is called.

3)
Added:
acceptAssetTransaction
assetTransferTransaction

4)
Reformatted indentation in Transaction.java
Added missing comments to Transaction.java

5)
Modified ApiException to include resoponseBody text with the message.

6)
Deprecated transactionWithSuggestedFeePerByte
replaced by Transaction.setFeeWithSuggestedFeePerByte