### PR TITLE
Asset send and accept transactions and other changes

### DIFF
--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -151,8 +151,8 @@ public class Account {
      * @throws NoSuchAlgorithmException crypto provider not found
      */
     public SignedTransaction signTransactionWithFeePerByte(Transaction tx, BigInteger feePerByte) throws NoSuchAlgorithmException {
-        Transaction feeTx = transactionWithSuggestedFeePerByte(tx, feePerByte);
-        return this.signTransaction(feeTx);
+        transactionWithSuggestedFeePerByte(tx, feePerByte);
+        return this.signTransaction(tx);
     }
 
     /**
@@ -177,34 +177,16 @@ public class Account {
 
     /**
      * Creates a version of the given transaction with fee populated according to suggestedFeePerByte * estimateTxSize.
-     * @param copyTx transaction to populate fee field
+     * @param tx transaction to populate fee field
      * @param suggestedFeePerByte suggestedFee given by network
-     * @return transaction with proper fee set
      * @throws NoSuchAlgorithmException could not estimate tx encoded size.
      */
-    static public Transaction transactionWithSuggestedFeePerByte(Transaction copyTx, BigInteger suggestedFeePerByte) throws NoSuchAlgorithmException{
-        BigInteger newFee = suggestedFeePerByte.multiply(estimatedEncodedSize(copyTx));
+    static public void transactionWithSuggestedFeePerByte(Transaction tx, BigInteger suggestedFeePerByte) throws NoSuchAlgorithmException{
+        BigInteger newFee = suggestedFeePerByte.multiply(estimatedEncodedSize(tx));
         if (newFee.compareTo(MIN_TX_FEE_UALGOS) < 0) {
             newFee = MIN_TX_FEE_UALGOS;
         }
-        switch (copyTx.type) {
-            case Payment:
-                return new Transaction(copyTx.sender, newFee, copyTx.firstValid, copyTx.lastValid, copyTx.note, copyTx.genesisID, copyTx.genesisHash,
-                        copyTx.amount, copyTx.receiver, copyTx.closeRemainderTo);
-            case KeyRegistration:
-                return new Transaction(copyTx.sender, newFee, copyTx.firstValid, copyTx.lastValid, copyTx.note, copyTx.genesisID, copyTx.genesisHash,
-                        copyTx.votePK, copyTx.selectionPK, copyTx.voteFirst, copyTx.voteLast, copyTx.voteKeyDilution);
-            case AssetConfig:
-                return new Transaction(copyTx.sender, newFee, copyTx.firstValid, copyTx.lastValid, copyTx.note, copyTx.genesisID, copyTx.genesisHash,
-                        copyTx.assetID, copyTx.assetParams);
-            case AssetFreeze:
-                return new Transaction(copyTx.sender, newFee, copyTx.firstValid, copyTx.lastValid, copyTx.note, copyTx.genesisID, copyTx.genesisHash,
-                        copyTx.assetFreezeID, copyTx.freezeTarget, copyTx.freezeState);
-            case Default:
-                throw new IllegalArgumentException("tx cannot have no type");
-            default:
-                throw new RuntimeException("cannot reach");
-        }
+        tx.setFee(newFee);
     }
 
     /**

--- a/src/main/java/com/algorand/algosdk/algod/client/ApiException.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ApiException.java
@@ -33,7 +33,7 @@ public class ApiException extends Exception {
     }
 
     public ApiException(String message, Throwable throwable, int code, Map<String, List<String>> responseHeaders, String responseBody) {
-        super(message, throwable);
+        super(message + " : " + responseBody, throwable);
         this.code = code;
         this.responseHeaders = responseHeaders;
         this.responseBody = responseBody;

--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -30,7 +30,7 @@ public class Transaction implements Serializable {
 
     // Instead of embedding POJOs and using JsonUnwrapped, we explicitly export inner fields. This circumvents our encoders'
     // inability to sort child fields.
-    /* header fields */
+    /* header fields ***********************************************************/
     @JsonProperty("snd")
     public Address sender = new Address();
     @JsonProperty("fee")
@@ -48,7 +48,7 @@ public class Transaction implements Serializable {
     @JsonProperty("grp")
     public Digest group = new Digest();
 
-    /* payment fields */
+    /* payment fields  *********************************************************/
     @JsonProperty("amt")
     public BigInteger amount = BigInteger.valueOf(0);
     @JsonProperty("rcv")
@@ -56,16 +56,18 @@ public class Transaction implements Serializable {
     @JsonProperty("close")
     public Address closeRemainderTo = new Address(); // can be null, optional
 
-    /* keyreg fields */
+    /* keyreg fields ***********************************************************/
     // VotePK is the participation public key used in key registration transactions
     @JsonProperty("votekey")
     public ParticipationPublicKey votePK = new ParticipationPublicKey();
+
     // selectionPK is the VRF public key used in key registration transactions
     @JsonProperty("selkey")
     public VRFPublicKey selectionPK = new VRFPublicKey();
     // voteFirst is the first round this keyreg tx is valid for
     @JsonProperty("votefst")
     public BigInteger voteFirst = BigInteger.valueOf(0);
+
     // voteLast is the last round this keyreg tx is valid for
     @JsonProperty("votelst")
     public BigInteger voteLast = BigInteger.valueOf(0);
@@ -73,12 +75,38 @@ public class Transaction implements Serializable {
     @JsonProperty("votekd")
     public BigInteger voteKeyDilution = BigInteger.valueOf(0);
     
-    /* asset creation and config fields */
+    /* asset creation and configuration fields *********************************/
     @JsonProperty("apar")
     public AssetParams assetParams = new AssetParams();
     @JsonProperty("caid")
     public AssetID assetID = new AssetID();
 
+    /* asset transfer fields ***************************************************/
+    @JsonProperty("xaid")
+    public AssetID xferAsset = new AssetID();
+
+    // The amount of asset to transfer. A zero amount transferred to self
+    // allocates that asset in the account's Assets map.
+    @JsonProperty("aamt")
+    public BigInteger assetAmount = BigInteger.valueOf(0);
+
+    // The sender of the transfer.  If this is not a zero value, the real
+    // transaction sender must be the Clawback address from the AssetParams. If
+    // this is the zero value, the asset is sent from the transaction's Sender.
+    @JsonProperty("asnd")
+    public Address assetSender = new Address();
+
+    // The receiver of the transfer.
+    @JsonProperty("arcv")
+    public Address assetReceiver = new Address();
+
+    // Indicates that the asset should be removed from the account's Assets map,
+    // and specifies where the remaining asset holdings should be transferred.
+    // It's always valid to transfer remaining asset holdings to the AssetID
+    // account.
+    @JsonProperty("aclose")
+    public Address assetCloseTo = new Address();
+    
     /* asset freeze fields */
     @JsonProperty("fadd")
     public Address freezeTarget = new Address();
@@ -87,6 +115,18 @@ public class Transaction implements Serializable {
     @JsonProperty("afrz")
     public boolean freezeState = false;
 
+
+    /**
+     * Set the transaction fee value.
+     * @param newFee the fee suggested for the transaction. If the
+     * newFee is less than the minimum transaction fee, it is replaced
+     * by the minimum fee. 
+     **/
+    public void setFee(BigInteger newFee) {
+        fee = newFee;
+    }    
+    
+    
     /**
      * Create a payment transaction
      * @param fromAddr source address
@@ -129,8 +169,17 @@ public class Transaction implements Serializable {
 
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note, String genesisID, Digest genesisHash,
                        BigInteger amount, Address receiver, Address closeRemainderTo) {
-        this(Type.Payment, sender, fee, firstValid, lastValid, note, genesisID, genesisHash, amount, receiver, closeRemainderTo,
-                new ParticipationPublicKey(), new VRFPublicKey(), BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(), new AssetParams(), new Address(), new AssetID(), false);
+        this.type = Type.Payment;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        if (amount != null) this.amount = amount;
+        if (receiver != null) this.receiver = receiver;
+        if (closeRemainderTo != null) this.closeRemainderTo = closeRemainderTo;
     }
 
     /**
@@ -151,9 +200,19 @@ public class Transaction implements Serializable {
                        ParticipationPublicKey votePK, VRFPublicKey vrfPK,
                        BigInteger voteFirst, BigInteger voteLast, BigInteger voteKeyDilution) {
         // populate with default values which will be ignored...
-        this(Type.KeyRegistration, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), votePK, vrfPK, voteFirst, voteLast, 
-                voteKeyDilution, new AssetID(), new AssetParams(), new Address(), new AssetID(), false);
+        this.type = Type.KeyRegistration;        
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;        
+        if (votePK != null) this.votePK = votePK;
+        if (vrfPK != null) this.selectionPK = vrfPK;
+        if (voteFirst != null) this.voteFirst = voteFirst;
+        if (voteLast != null) this.voteLast = voteLast;
+        if (voteKeyDilution != null) this.voteKeyDilution = voteKeyDilution;
     }
 
     /**
@@ -177,10 +236,16 @@ public class Transaction implements Serializable {
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
                        String genesisID, Digest genesisHash, BigInteger assetTotal, boolean defaultFrozen,
                        String assetUnitName, String assetName, Address manager, Address reserve, Address freeze, Address clawback) {
-        // populate ignored values with default or null values
-        this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(), 
-                new AssetParams(assetTotal, defaultFrozen, assetUnitName, assetName, manager, reserve, freeze, clawback), new Address(), new AssetID(), false);
+        this.type = Type.AssetConfig;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+ 
+        this.assetParams = new AssetParams(assetTotal, defaultFrozen, assetUnitName, assetName, manager, reserve, freeze, clawback);        
     }
 
     /**
@@ -204,17 +269,31 @@ public class Transaction implements Serializable {
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
                        String genesisID, Digest genesisHash, Address creator, BigInteger index,
                     Address manager, Address reserve, Address freeze, Address clawback) {
-        // populate ignored values with default or null values
-        this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), new AssetID(creator, index), 
-                new AssetParams(BigInteger.valueOf(0), false, "", "", manager, reserve, freeze, clawback), new Address(), new AssetID(), false);
-    }
+ 
+        this.type = Type.AssetConfig;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        this.assetParams = new AssetParams(BigInteger.valueOf(0), false, "", "", manager, reserve, freeze, clawback);
+        assetID = new AssetID(creator, index);
+    }        
 
     public Transaction(Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
                        String genesisID, Digest genesisHash, AssetID assetID, AssetParams assetParams) {
-        // populate ignored values with default or null values
-        this(Type.AssetConfig, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), assetID, assetParams, new Address(), new AssetID(), false);
+        this.type = Type.AssetConfig;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        if (assetParams != null) this.assetParams = assetParams;
+        if (assetID != null) this.assetID = assetID;
     }
 
     /**
@@ -232,15 +311,23 @@ public class Transaction implements Serializable {
      */
     public Transaction (Address sender, BigInteger fee, BigInteger firstValid, BigInteger lastValid, byte[] note,
                         String genesisID, Digest genesisHash, AssetID assetFreezeID, Address freezeTarget, boolean freezeState) {
-        // populate ignored values with default or null values
-        this(Type.AssetFreeze, sender, fee, firstValid, lastValid, note, genesisID, genesisHash,
-                BigInteger.valueOf(0), new Address(), new Address(), null, null, BigInteger.valueOf(0), BigInteger.valueOf(0), BigInteger.valueOf(0), null, null,
-                freezeTarget, assetFreezeID, freezeState);
+        this.type = Type.AssetFreeze;
+        if (sender != null) this.sender = sender;
+        if (fee != null) this.fee = fee;
+        if (firstValid != null) this.firstValid = firstValid;
+        if (lastValid != null) this.lastValid = lastValid;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        if (freezeTarget != null) this.freezeTarget = freezeTarget;
+        if (assetFreezeID != null) this.assetFreezeID = assetFreezeID;
+        this.freezeState = freezeState;
     }
-
+    
     // workaround for nested JsonValue classes
     @JsonCreator
     private Transaction(@JsonProperty("type") Type type,
+                        //header fields
                         @JsonProperty("snd") byte[] sender,
                         @JsonProperty("fee") BigInteger fee,
                         @JsonProperty("fv") BigInteger firstValid,
@@ -248,27 +335,71 @@ public class Transaction implements Serializable {
                         @JsonProperty("note") byte[] note,
                         @JsonProperty("gen") String genesisID,
                         @JsonProperty("gh") byte[] genesisHash,
-                        @JsonProperty("grp") byte[] group,
+                        @JsonProperty("grp") byte[] group,			
+                        // payment fields
                         @JsonProperty("amt") BigInteger amount,
                         @JsonProperty("rcv") byte[] receiver,
                         @JsonProperty("close") byte[] closeRemainderTo,
+                        // keyreg fields
                         @JsonProperty("votekey") byte[] votePK,
                         @JsonProperty("selkey") byte[] vrfPK,
                         @JsonProperty("votefst") BigInteger voteFirst,
                         @JsonProperty("votelst") BigInteger voteLast,
                         @JsonProperty("votekd") BigInteger voteKeyDilution,
-                        @JsonProperty("caid") AssetID assetID,
+                        // asset creation and configuration
                         @JsonProperty("apar") AssetParams assetParams,
+                        @JsonProperty("caid") AssetID assetID,
+                        // Asset xfer transaction fields
+                        @JsonProperty("xaid") AssetID xferAsset,
+                        @JsonProperty("aamt") BigInteger assetAmount,
+                        @JsonProperty("asnd") byte[] assetSender,
+                        @JsonProperty("arcv") byte[] assetReceiver,
+                        @JsonProperty("aclose") byte[] assetCloseTo,
+                        // asset freeze fields
                         @JsonProperty("fadd") byte[] freezeTarget,
                         @JsonProperty("faid") AssetID assetFreezeID,
                         @JsonProperty("afrz") boolean freezeState) {
-        this(type, new Address(sender), fee, firstValid, lastValid, note, genesisID, new Digest(genesisHash), amount,
-                new Address(receiver), new Address(closeRemainderTo), new ParticipationPublicKey(votePK), new VRFPublicKey(vrfPK),
-                voteFirst, voteLast, voteKeyDilution, assetID, assetParams, new Address(freezeTarget), assetFreezeID, freezeState);
-        if (group != null) this.group = new Digest(group);
+        this(
+	     type,
+	     //header fields
+	     new Address(sender),
+	     fee,
+	     firstValid,
+	     lastValid,
+	     note,
+	     genesisID,
+	     new Digest(genesisHash),
+	     new Digest(group),
+	     // payment fields
+	     amount,
+	     new Address(receiver),
+	     new Address(closeRemainderTo),
+	     // keyreg fields
+	     new ParticipationPublicKey(votePK),
+	     new VRFPublicKey(vrfPK),
+	     voteFirst,
+	     voteLast,
+	     voteKeyDilution,
+	     // asset creation and configuration
+	     assetParams,
+	     assetID,
+	     // asset transfer fields
+	     xferAsset,
+	     assetAmount,
+	     new Address(assetSender),
+	     new Address(assetReceiver),
+	     new Address(assetCloseTo),
+	     new Address(freezeTarget),
+	     assetFreezeID,
+	     freezeState);
     }
 
-    private Transaction(Type type,
+    /**
+     * This is the private constructor which takes all the fields of Transaction
+     **/
+    private Transaction(
+                        Type type,
+                        //header fields
                         Address sender,
                         BigInteger fee,
                         BigInteger firstValid,
@@ -276,16 +407,27 @@ public class Transaction implements Serializable {
                         byte[] note,
                         String genesisID,
                         Digest genesisHash,
+                        Digest group,
+                        // payment fields
                         BigInteger amount,
                         Address receiver,
                         Address closeRemainderTo,
+                        // keyreg fields
                         ParticipationPublicKey votePK,
                         VRFPublicKey vrfPK,
                         BigInteger voteFirst,
                         BigInteger voteLast,
+                        // voteKeyDilution
                         BigInteger voteKeyDilution,
-                        AssetID assetID,
+                        // asset creation and configuration
                         AssetParams assetParams,
+                        AssetID assetID,
+                        // asset transfer fields
+                        AssetID xferAsset,
+                        BigInteger assetAmount,
+                        Address assetSender,
+                        Address assetReceiver,
+                        Address assetCloseTo,
                         Address freezeTarget,
                         AssetID assetFreezeID,
                         boolean freezeState) {
@@ -297,6 +439,7 @@ public class Transaction implements Serializable {
         if (note != null) this.note = note;
         if (genesisID != null) this.genesisID = genesisID;
         if (genesisHash != null) this.genesisHash = genesisHash;
+        if (group != null) this.group = group;	
         if (amount != null) this.amount = amount;
         if (receiver != null) this.receiver = receiver;
         if (closeRemainderTo != null) this.closeRemainderTo = closeRemainderTo;
@@ -305,8 +448,13 @@ public class Transaction implements Serializable {
         if (voteFirst != null) this.voteFirst = voteFirst;
         if (voteLast != null) this.voteLast = voteLast;
         if (voteKeyDilution != null) this.voteKeyDilution = voteKeyDilution;
-        if (assetID != null) this.assetID = assetID;
         if (assetParams != null) this.assetParams = assetParams;
+        if (assetID != null) this.assetID = assetID;
+        if (xferAsset != null) this.xferAsset = xferAsset;
+        if (assetAmount != null) this.assetAmount = assetAmount;
+        if (assetSender != null) this.assetSender = assetSender;
+        if (assetReceiver != null) this.assetReceiver = assetReceiver;
+        if (assetCloseTo != null) this.assetCloseTo = assetCloseTo;
         if (freezeTarget != null) this.freezeTarget = freezeTarget;
         if (assetFreezeID != null) this.assetFreezeID = assetFreezeID;
         this.freezeState = freezeState;
@@ -314,6 +462,147 @@ public class Transaction implements Serializable {
 
     public Transaction() {}
 
+
+    /**
+     * Base constructor with flat fee for asset xfer transactions.
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    private Transaction(// Asset xfer transaction
+            BigInteger flatFee,
+            BigInteger firstRound,
+            BigInteger lastRound,
+            byte [] note,
+            String genesisID,
+            Digest genesisHash,
+            Address assetCreator,
+            BigInteger assetIndex) {
+
+        this.type = Type.AssetTransfer;
+        if (flatFee != null) this.fee = flatFee;
+        if (firstRound != null) this.firstValid = firstRound;
+        if (lastRound != null) this.lastValid = lastRound;
+        if (note != null) this.note = note;
+        if (genesisID != null) this.genesisID = genesisID;
+        if (genesisHash != null) this.genesisHash = genesisHash;
+        if (assetCreator != null) this.xferAsset = new AssetID(assetCreator,
+                assetIndex);
+
+    }
+
+    /**
+     * Creates a tx to mark the account as willing to accept the asset.
+     * @param acceptingAccount is a checksummed, human-readable address that
+     * will accept receiving the asset.
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    public static Transaction createAcceptAssetTransaction( //AssetTransaction
+            Address acceptingAccount, 
+            BigInteger flatFee,
+            BigInteger firstRound,
+            BigInteger lastRound,
+            byte [] note,
+            String genesisID,
+            Digest genesisHash,
+            Address assetCreator,
+            BigInteger assetIndex) {
+
+        Transaction tx = createTransferAssetTransaction(
+                acceptingAccount,
+                acceptingAccount,
+                new Address(),
+                BigInteger.valueOf(0),
+                flatFee,
+                firstRound,
+                lastRound,
+                note,
+                genesisID,
+                genesisHash,
+                assetCreator,
+                assetIndex);
+
+        return tx;
+    }
+
+    /**
+     * Creates a tx for sending some asset from an asset holder to another user.
+     *  The asset receiver must have marked itself as willing to accept the
+     *  asset.
+     * @param assetSender is a checksummed, human-readable address that will
+     * send the transaction and assets
+     * @param assetReceiver is a checksummed, human-readable address what will
+     * receive the assets
+     * @param assetCloseTo is a checksummed, human-readable address that
+     * behaves as a close-to address for the asset transaction; the remaining
+     * assets not sent to assetReceiver will be sent to assetCloseTo. Leave
+     * blank for no close-to behavior.
+     * @param assetAmount is the number of assets to send
+     * @param flatFee is the transaction flat fee
+     * @param firstRound is the first round this txn is valid (txn semantics
+     * unrelated to asset management)
+     * @param lastRound is the last round this txn is valid
+     * @param note
+     * @param genesisID corresponds to the id of the network
+     * @param genesisHash corresponds to the base64-encoded hash of the genesis
+     * of the network
+     * @param assetCreator is the address of the asset creator
+     * @param assetIndex is the asset index
+     **/
+    public static Transaction createTransferAssetTransaction(// AssetTransaction
+            Address assetSender,
+            Address assetReceiver,
+            Address assetCloseTo,
+            BigInteger assetAmount,
+            BigInteger flatFee,
+            BigInteger firstRound,
+            BigInteger lastRound,
+            byte [] note,
+            String genesisID,
+            Digest genesisHash,
+            Address assetCreator,
+            BigInteger assetIndex) {
+
+        Transaction tx = new Transaction(
+                flatFee,    // fee
+                firstRound, // fv
+                lastRound, // lv
+                note, //note
+                genesisID, // gen
+                genesisHash, // gh
+                assetCreator, // c
+                assetIndex); // i
+
+        tx.assetReceiver = assetReceiver; //arcv
+        tx.assetCloseTo = assetCloseTo; // aclose
+        tx.assetAmount = assetAmount; // aamt
+        tx.sender = assetSender; // snd
+        return tx;
+    }
+
+
+
+
+
+
+
+    
     /**
      * TxType represents a transaction type.
      */
@@ -322,6 +611,7 @@ public class Transaction implements Serializable {
         Payment("pay"),
         KeyRegistration("keyreg"),
         AssetConfig("acfg"),
+        AssetTransfer("axfer"),
         AssetFreeze("afrz");
 
         private final String value;
@@ -414,6 +704,11 @@ public class Transaction implements Serializable {
                 voteKeyDilution.equals(that.voteKeyDilution) &&
                 assetParams.equals(that.assetParams) &&
                 assetID.equals(that.assetID) &&
+	        xferAsset.equals(that.xferAsset) &&
+       	        assetAmount.equals(that.assetAmount) &&
+	        assetSender.equals(that.assetSender) &&
+	        assetReceiver.equals(that.assetReceiver) &&
+	        assetCloseTo.equals(that.assetCloseTo) &&
                 freezeTarget.equals(that.freezeTarget) &&
                 assetFreezeID.equals(that.assetFreezeID) &&
                 freezeState == that.freezeState;

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -5,6 +5,7 @@ import com.algorand.algosdk.crypto.Address;
 import com.algorand.algosdk.crypto.Digest;
 import com.algorand.algosdk.crypto.Signature;
 import com.algorand.algosdk.crypto.MultisigSignature;
+import com.algorand.algosdk.mnemonic.Mnemonic;
 import com.algorand.algosdk.util.Encoder;
 import org.junit.Assert;
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class TestTransaction {
         Address clawback = addr;
 
         Transaction tx = new Transaction(sender, BigInteger.valueOf(10), BigInteger.valueOf(322575), BigInteger.valueOf(323575), null, "", new Digest(gh), creator, BigInteger.valueOf(1234), manager, reserve, freeze, clawback);
-        tx = Account.transactionWithSuggestedFeePerByte(tx, BigInteger.valueOf(10));
+        Account.transactionWithSuggestedFeePerByte(tx, BigInteger.valueOf(10));
 
         byte[] outBytes = Encoder.encodeToMsgPack(tx);
         byte[] golden = Encoder.decodeFromBase64("iKRhcGFyhKFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFmxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFtxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFyxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRjYWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpzQTSo2ZlZc0OzqJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/3o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhY2Zn");
@@ -93,7 +94,7 @@ public class TestTransaction {
         boolean freezeState = true;
         Transaction tx = new Transaction(sender, BigInteger.valueOf(10), BigInteger.valueOf(322575), BigInteger.valueOf(323575), null,
                 "", new Digest(gh), assetFreezeID, target, freezeState);
-        tx = Account.transactionWithSuggestedFeePerByte(tx, BigInteger.valueOf(10));
+        Account.transactionWithSuggestedFeePerByte(tx, BigInteger.valueOf(10));
         byte[] outBytes = Encoder.encodeToMsgPack(tx);
         Transaction o = Encoder.decodeFromMsgPack(outBytes, Transaction.class);
         byte[] golden = Encoder.decodeFromBase64("iaRhZnJ6w6RmYWRkxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aRmYWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAaNmZWXNCqCiZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWkYWZyeg==");
@@ -182,5 +183,142 @@ public class TestTransaction {
     public void testTransactionGroupNull() throws IOException {
         TxGroup.computeGroupID(null);
         Assert.fail("no expected exception");
+    }
+    
+    @Test
+    public void testMakeAssetAcceptanceTxn() throws Exception {
+
+        final String FROM_SK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred";
+        byte[] seed = Mnemonic.toKey(FROM_SK);
+        Account account = new Account(seed);
+
+        Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");
+        byte[] gh = Encoder.decodeFromBase64("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+        Address recipient = addr;
+        Address creator = addr;
+
+        BigInteger assetIndex = BigInteger.valueOf(1);
+        BigInteger firstValidRound = BigInteger.valueOf(322575);
+        BigInteger lastValidRound = BigInteger.valueOf(323575);
+
+        Transaction tx = Transaction.createAcceptAssetTransaction(
+                recipient,
+                BigInteger.valueOf(10),
+                firstValidRound,
+                lastValidRound,
+                null,
+                "",
+                new Digest(gh),
+                creator,
+                assetIndex);
+
+        Account.transactionWithSuggestedFeePerByte(tx, tx.fee);
+        byte[] outBytes = Encoder.encodeToMsgPack(tx);
+        Transaction o = Encoder.decodeFromMsgPack(outBytes, Transaction.class);
+        Assert.assertEquals(o,  tx);
+
+        /*  Example from: go-algorand-sdk/transaction/transaction_test.go
+         *  {
+         *     "sig:b64": "0u7LDECdsm6RA0vqlX3w09zsDTNih1eYrwuIbISB64HMi4opQXdEZnWwJfbu31CWfkyTR+cGJ1aR7T7e4oHKDw==",
+         *     "txn": {
+         *       "arcv:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *       "fee": 2670,
+         *       "fv": 322575,
+         *       "gh:b64": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+         *       "lv": 323575,
+         *       "snd:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *       "type": "axfer",
+         *       "xaid": {
+         *         "c:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *         "i": 1
+         *       }
+         *     }
+         *   }
+         */
+        SignedTransaction stx = account.signTransaction(tx);
+        byte[] signedOutBytes = Encoder.encodeToMsgPack(stx);
+        byte[] golden = Encoder.decodeFromBase64("gqNzaWfEQNLuywxAnbJukQNL6pV98NPc7A0zYodXmK8LiGyEgeuBzIuKKUF3RGZ1sCX27t9Qln5Mk0fnBidWke0+3uKByg+jdHhuiKRhcmN2xCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aNmZWXNCm6iZnbOAATsD6JnaMQgSGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiKibHbOAATv96NzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWlYXhmZXKkeGFpZIKhY8QgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2haQE=");
+
+        SignedTransaction stxDecoded = Encoder.decodeFromMsgPack(signedOutBytes, SignedTransaction.class);
+        Assert.assertEquals(stx, stxDecoded);
+        Assert.assertArrayEquals(signedOutBytes, golden);
+    }
+
+
+    @Test
+    public void testMakeAssetTransferTxn() throws Exception {
+
+        final String FROM_SK = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred";
+        byte[] seed = Mnemonic.toKey(FROM_SK);
+        Account account = new Account(seed);
+
+        Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");
+        byte[] gh = Encoder.decodeFromBase64("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+        Address sender = addr;
+        Address recipient = addr;
+        Address creator = addr;
+        Address closeAssetsTo = addr;
+
+        BigInteger assetIndex = BigInteger.valueOf(1);
+        BigInteger firstValidRound = BigInteger.valueOf(322575);
+        BigInteger lastValidRound = BigInteger.valueOf(323576);
+        BigInteger amountToSend = BigInteger.valueOf(1);
+
+        Transaction tx = Transaction.createTransferAssetTransaction(
+                sender,
+                recipient,
+                closeAssetsTo,
+                amountToSend,
+                BigInteger.valueOf(10),
+                firstValidRound,
+                lastValidRound,
+                null,
+                "",
+                new Digest(gh),
+                creator,
+                assetIndex);
+
+        Account.transactionWithSuggestedFeePerByte(tx, tx.fee);
+        byte[] outBytes = Encoder.encodeToMsgPack(tx);
+        Transaction o = Encoder.decodeFromMsgPack(outBytes, Transaction.class);
+        Assert.assertEquals(o,  tx);
+
+        /*
+         * Golden from: go-algorand-sdk/transaction/transaction_test.go
+         *{
+         *  "sig:b64": "aST0K284qefidTn3GY8ahm9i/7pMK7kH3k+DBD9jK3AT12vX316ESoCdJLQLZJo7hiEQECT4lU6LBmJGr/DWCA==",
+         *  "txn": {
+         *    "aamt": 1,
+         *    "aclose:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *    "arcv:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *    "fee": 3140,
+         *    "fv": 322575,
+         *    "gh:b64": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+         *    "lv": 323576,
+         *    "snd:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *    "type": "axfer",
+         *    "xaid": {
+         *      "c:b64": "CfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f0=",
+         *      "i": 1
+         *    }
+         *  }
+         *}
+         *
+         * goal command:
+         * goal asset send  -a 1
+         * --from     BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4
+         * --to       BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4
+         * --creator  BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4
+         * --close-to BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4
+         * --assetid 1 -s
+         */
+
+        SignedTransaction stx = account.signTransaction(tx);
+        byte[] signedOutBytes = Encoder.encodeToMsgPack(stx);
+        byte[] golden = Encoder.decodeFromBase64("gqNzaWfEQGkk9CtvOKnn4nU59xmPGoZvYv+6TCu5B95PgwQ/YytwE9dr199ehEqAnSS0C2SaO4YhEBAk+JVOiwZiRq/w1gijdHhuiqRhYW10AaZhY2xvc2XEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pGFyY3bEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9o2ZlZc0MRKJmds4ABOwPomdoxCBIY7UYpLPITsgQ8i1PEIHLD3HwWaesIN7GL39w5Qk6IqJsds4ABO/4o3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaVheGZlcqR4YWlkgqFjxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aFpAQ==");
+        SignedTransaction stxDecoded = Encoder.decodeFromMsgPack(signedOutBytes, SignedTransaction.class);
+
+        Assert.assertEquals(stx, stxDecoded);
+        Assert.assertArrayEquals(signedOutBytes, golden);
     }
 }


### PR DESCRIPTION
1)
Added asset xfer and accept transaction methods:
createAcceptAssetTransaction
createTransferAssetTransaction

2)
Modified some of the Transaction constructors not to call the other constructor used for creating Transactions from json.
Otherwise, every time a new field is added, all these constructors will need updating to pass null values.

3)
Modified ApiException to include resoponseBody text with the message. This is to enhance the error reporting downstream.

4)
Changed Account.transactionWithSuggestedFeePerByte not to return a new transaction, but to set the transaction fee on the passed transaction object. This corrects the shallow copy problem: it was returning a new transaction with shallow copied members from the original transaction.

5)
Added tests to asset transfer and asset accept transactions with signed golden.