### PR TITLE
DynamicFee Template

### DIFF
--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -46,7 +46,7 @@ public class Account {
     private static final int SK_SIZE_BITS = SK_SIZE * 8;
     private static final byte[] BID_SIGN_PREFIX = ("aB").getBytes(StandardCharsets.UTF_8);
     private static final byte[] BYTES_SIGN_PREFIX = ("MX").getBytes(StandardCharsets.UTF_8);
-    private static final BigInteger MIN_TX_FEE_UALGOS = BigInteger.valueOf(1000);
+    public static final BigInteger MIN_TX_FEE_UALGOS = BigInteger.valueOf(1000);
 
     /**
      * Account creates a new, random account.

--- a/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
+++ b/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
@@ -1,0 +1,150 @@
+package com.algorand.algosdk.templates;
+
+import com.algorand.algosdk.account.Account;
+import com.algorand.algosdk.crypto.Address;
+import com.algorand.algosdk.crypto.Digest;
+import com.algorand.algosdk.crypto.LogicsigSignature;
+import com.algorand.algosdk.logic.Logic;
+import com.algorand.algosdk.templates.ContractTemplate.AddressParameterValue;
+import com.algorand.algosdk.templates.ContractTemplate.BytesParameterValue;
+import com.algorand.algosdk.templates.ContractTemplate.IntParameterValue;
+import com.algorand.algosdk.templates.ContractTemplate.ParameterValue;
+import com.algorand.algosdk.transaction.SignedTransaction;
+import com.algorand.algosdk.transaction.Transaction;
+import com.algorand.algosdk.transaction.TxGroup;
+import com.algorand.algosdk.util.Encoder;
+import com.algorand.algosdk.transaction.Lease;
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Objects;
+
+public class DynamicFee {
+    protected static String referenceProgram = "ASAFAgEFBgcmAyD+vKC7FEpaTqe0OKRoGsgObKEFvLYH/FZTJclWlfaiEyDmmpYeby1feshmB5JlUr6YI17TM2PKiJGLuck4qRW2+QEGMgQiEjMAECMSEDMABzEAEhAzAAgxARIQMRYjEhAxECMSEDEHKBIQMQkpEhAxCCQSEDECJRIQMQQhBBIQMQYqEhA=";
+    private static int [] referenceOffsets = {5, 6, 7, 11, 44, 76};
+
+    /**
+     * DynamicFee contract allows you to create a transaction without
+     * specifying the fee. The fee will be determined at the moment of
+     * transfer.
+     *
+     * @param receiver (str): address to receive the assets
+     * @param amount (int): amount of assets to transfer
+     * @param firstValid (int): first valid round for the transaction
+     * @param lastValid (int, optional): last valid round for the transaction (default to first_valid + 1000)
+     * @param closeRemainderAddress (str, optional): if you would like to close the account after the transfer, specify the address that would recieve the remainder
+     */
+    public static ContractTemplate MakeDynamicFee(final Address receiver, final Integer amount, final Integer firstValid, final Integer lastValid, final Address closeRemainderAddress) throws NoSuchAlgorithmException {
+        return MakeDynamicFee(receiver, amount, firstValid, lastValid, closeRemainderAddress, null);
+    }
+
+    protected static ContractTemplate MakeDynamicFee(final Address receiver, final Integer amount, final Integer firstValid, final Integer lastValid, final Address closeRemainderAddress, final Lease lease) throws NoSuchAlgorithmException {
+        Objects.requireNonNull(receiver);
+        Objects.requireNonNull(amount);
+        Objects.requireNonNull(firstValid);
+
+        byte[] program = Encoder.decodeFromBase64(referenceProgram);
+
+        ParameterValue[] values = {
+                new IntParameterValue(amount),
+                new IntParameterValue(firstValid),
+                new IntParameterValue(lastValid == null ? firstValid + 1000 : lastValid),
+                new AddressParameterValue(receiver),
+                new AddressParameterValue(closeRemainderAddress == null ? new Address() : closeRemainderAddress),
+                new BytesParameterValue(lease == null ? new Lease() : lease)
+        };
+
+        return ContractTemplate.inject(program, referenceOffsets, values);
+    }
+
+    /**
+     * Container class for the signed dynamic fee data returned by SignDynamicFee.
+     */
+    public static class SignedDynamicFee {
+        public final Transaction txn;
+        public final LogicsigSignature lsig;
+
+        private SignedDynamicFee(final Transaction txn, final LogicsigSignature lsig) {
+            this.txn = txn;
+            this.lsig = lsig;
+        }
+    }
+
+    /**
+     * Return the main transaction and signed logic needed to complete the
+     * transfer. These should be sent to the fee payer, who can use
+     * get_transactions() to update fields and create the auxiliary
+     * transaction.
+     *
+     * @param contract DynamicFee contract created with MakeDynamicFee.
+     * @param senderAccount sender account to sign the transaction.
+     * @param genesisHash Genesis hash for the network where the transaction will be submitted.
+     * @return
+     */
+    public static SignedDynamicFee SignDynamicFee(final ContractTemplate contract, final Account senderAccount, final Digest genesisHash) throws IOException {
+        Logic.ProgramData data = Logic.readProgram(contract.program, null);
+        Address receiverAddress = new Address(data.byteBlock.get(0));
+        Address closeToAddress = new Address(data.byteBlock.get(1));
+        Lease lease = new Lease(data.byteBlock.get(2));
+
+        BigInteger amount = BigInteger.valueOf(data.intBlock.get(2));
+        BigInteger firstValid = BigInteger.valueOf(data.intBlock.get(3));
+        BigInteger lastValid = BigInteger.valueOf(data.intBlock.get(4));
+
+        Transaction txn = new Transaction(
+                senderAccount.getAddress(),
+                BigInteger.valueOf(0),
+                firstValid,
+                lastValid,
+                null,
+                "",
+                genesisHash,
+                amount,
+                receiverAddress,
+                closeToAddress);
+        txn.setLease(lease);
+
+        LogicsigSignature lsig = senderAccount.signLogicsig(new LogicsigSignature(contract.program));
+
+        return new SignedDynamicFee(txn, lsig);
+    }
+
+    /**
+     * Create and sign the secondary dynamic fee transaction, update
+     * transaction fields, and sign as the fee payer; return both
+     * transactions.
+     *
+     * @param txn main transaction from payer
+     * @param lsig signed logic received from payer
+     * @param account an account initialized with a signing key.
+     * @param feePerByte fee per byte, for both transactions
+     */
+    public static List<SignedTransaction> MakeReimbursementTransactions(final Transaction txn, final LogicsigSignature lsig, final Account account, final int feePerByte) throws NoSuchAlgorithmException, IOException {
+        txn.fee = Account.MIN_TX_FEE_UALGOS;
+        Account.setFeeByFeePerByte(txn, BigInteger.valueOf(feePerByte));
+
+        // Reimbursement transaction
+        Transaction txn2 = new Transaction(
+                account.getAddress(),
+                BigInteger.valueOf(feePerByte),
+                txn.firstValid,
+                txn.lastValid,
+                null,
+                txn.genesisID,
+                txn.genesisHash,
+                txn.fee,
+                txn.sender,
+                null);
+        txn2.setLease(new Lease(txn.lease));
+        Account.setFeeByFeePerByte(txn2, BigInteger.valueOf(feePerByte));
+
+        TxGroup.assignGroupID(null, txn, txn2);
+        SignedTransaction stx1 = new SignedTransaction(txn, lsig, txn.txID());
+        SignedTransaction stx2 = account.signTransaction(txn2);
+
+        return ImmutableList.of(stx1, stx2);
+    }
+}

--- a/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
+++ b/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
@@ -16,9 +16,11 @@ import com.algorand.algosdk.util.Encoder;
 import com.algorand.algosdk.transaction.Lease;
 import com.google.common.collect.ImmutableList;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -120,7 +122,7 @@ public class DynamicFee {
     /**
      * Create and sign the secondary dynamic fee transaction, update
      * transaction fields, and sign as the fee payer; return both
-     * transactions.
+     * transactions ready to be sent.
      *
      * Create the Transaction and LogicsigSignature objects from base64 encoded objects:
      * Encoder.decodeFromMsgPack(encodedTxn, Transaction.class),
@@ -131,7 +133,7 @@ public class DynamicFee {
      * @param account an account initialized with a signing key.
      * @param feePerByte fee per byte, for both transactions
      */
-    public static List<SignedTransaction> MakeReimbursementTransactions(final Transaction txn, final LogicsigSignature lsig, final Account account, final int feePerByte) throws NoSuchAlgorithmException, IOException {
+    public static byte[] MakeReimbursementTransactions(final Transaction txn, final LogicsigSignature lsig, final Account account, final int feePerByte) throws NoSuchAlgorithmException, IOException {
         // Due to an issue with how transactions are initialized, the fee at
         // this point is inconsistent between SDKs. Adjust the fee here to
         // allow the same goldens to be used across all SDKs.
@@ -157,6 +159,9 @@ public class DynamicFee {
         SignedTransaction stx1 = new SignedTransaction(txn, lsig, txn.txID());
         SignedTransaction stx2 = account.signTransaction(txn2);
 
-        return ImmutableList.of(stx1, stx2);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write(Encoder.encodeToMsgPack(stx1));
+        baos.write(Encoder.encodeToMsgPack(stx2));
+        return baos.toByteArray();
     }
 }

--- a/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
+++ b/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
@@ -123,6 +123,9 @@ public class DynamicFee {
      * @param feePerByte fee per byte, for both transactions
      */
     public static List<SignedTransaction> MakeReimbursementTransactions(final Transaction txn, final LogicsigSignature lsig, final Account account, final int feePerByte) throws NoSuchAlgorithmException, IOException {
+        // Due to an issue with how transactions are initialized, the fee at
+        // this point is inconsistent between SDKs. Adjust the fee here to
+        // allow the same goldens to be used across all SDKs.
         txn.fee = Account.MIN_TX_FEE_UALGOS;
         Account.setFeeByFeePerByte(txn, BigInteger.valueOf(feePerByte));
 

--- a/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
+++ b/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
@@ -79,6 +79,11 @@ public class DynamicFee {
      * get_transactions() to update fields and create the auxiliary
      * transaction.
      *
+     * The transaction and logicsig should be sent to the other party as base64 encoded objects:
+     * SignedDynamicFee sdf = DynamicFee.SignDynamicFee(...);
+     * String encodedLsig = Encoder.encodeToBase64(Encoder.encodeToMsgPack(sdf.lsig));
+     * String encodedTxn = Encoder.encodeToBase64(Encoder.encodeToMsgPack(sdf.txn));
+     *
      * @param contract DynamicFee contract created with MakeDynamicFee.
      * @param senderAccount sender account to sign the transaction.
      * @param genesisHash Genesis hash for the network where the transaction will be submitted.
@@ -116,6 +121,10 @@ public class DynamicFee {
      * Create and sign the secondary dynamic fee transaction, update
      * transaction fields, and sign as the fee payer; return both
      * transactions.
+     *
+     * Create the Transaction and LogicsigSignature objects from base64 encoded objects:
+     * Encoder.decodeFromMsgPack(encodedTxn, Transaction.class),
+     * Encoder.decodeFromMsgPack(encodedLsig, LogicsigSignature.class),
      *
      * @param txn main transaction from payer
      * @param lsig signed logic received from payer

--- a/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
+++ b/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
@@ -117,16 +117,9 @@ public class TestTemplates {
 		// Sign contract
 		DynamicFee.SignedDynamicFee sdf = DynamicFee.SignDynamicFee(program, account1, gh);
 
+		// Generate signed transactions (using data that would be passed to another person).
 		byte[] signedLsig = Encoder.encodeToMsgPack(sdf.lsig);
 		byte[] txn = Encoder.encodeToMsgPack(sdf.txn);
-
-    /*
-		String goldenLsig = "gqFsxLEBIAUCAYgnuWC6YCYDIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITIOaalh5vLV96yGYHkmVSvpgjXtMzY8qIkYu5yTipFbb5IH+DsWV/8fxTuS3BgUih1l38LUsfo9Z3KErd0gASbZBpMgQiEjMAECMSEDMABzEAEhAzAAgxARIQMRYjEhAxECMSEDEHKBIQMQkpEhAxCCQSEDECJRIQMQQhBBIQMQYqEhCjc2lnxEAhLNdfdDp9Wbi0YwsEQCpP7TVHbHG7y41F4MoESNW/vL1guS+5Wj4f5V9fmM63/VKTSMFidHOSwm5o+pbV5lYH";
-		assertThat(signedLsig).isEqualTo(Encoder.decodeFromBase64(goldenLsig));
-		assertThat(Encoder.encodeToMsgPack(sdf.txn)).isEqualTo(Encoder.decodeFromBase64(goldenTxn));
-    */
-
-		// Generate signed transactions (using data that would be passed to another person).
 		List<SignedTransaction> stxns = DynamicFee.MakeReimbursementTransactions(
 				Encoder.decodeFromMsgPack(txn, Transaction.class),
 				Encoder.decodeFromMsgPack(signedLsig, LogicsigSignature.class),
@@ -137,7 +130,6 @@ public class TestTemplates {
 		for (SignedTransaction stxn : stxns) {
 			stxStr += Encoder.encodeToBase64(Encoder.encodeToMsgPack(stxn));
 		}
-		System.out.println(Encoder.encodeToBase64(Encoder.encodeToMsgPack(stxns.get(0))));
 
 		String goldenStxns = "gqRsc2lngqFsxLEBIAUCAYgnuWC6YCYDIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITIOaalh5vLV96yGYHkmVSvpgjXtMzY8qIkYu5yTipFbb5IH+DsWV/8fxTuS3BgUih1l38LUsfo9Z3KErd0gASbZBpMgQiEjMAECMSEDMABzEAEhAzAAgxARIQMRYjEhAxECMSEDEHKBIQMQkpEhAxCCQSEDECJRIQMQQhBBIQMQYqEhCjc2lnxEAhLNdfdDp9Wbi0YwsEQCpP7TVHbHG7y41F4MoESNW/vL1guS+5Wj4f5V9fmM63/VKTSMFidHOSwm5o+pbV5lYHo3R4boujYW10zROIpWNsb3NlxCDmmpYeby1feshmB5JlUr6YI17TM2PKiJGLuck4qRW2+aNmZWXOAAWq6qJmds0wOaJnaMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjZ3JwxCBRpaRVpA3ImXU4/ENcrzp+jsooLVHC7bF5kCGUK0KORaJsds0wOqJseMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjcmN2xCD+vKC7FEpaTqe0OKRoGsgObKEFvLYH/FZTJclWlfaiE6NzbmTEIIU9h0wnKapwajF0N7K4zy3orGLF+rQ8kLIk/vW6FhPvpHR5cGWjcGF5gqNzaWfEQAilsGaC4M4zfYN5QpvREdHEC0DjI2ZWCXSIwwyUWHg2dzd5gKR2Cqu+iUmiCU1hOTTiOump3PILTgWeG0ZkUAajdHhuiqNhbXTOAAWq6qNmZWXOAATzvqJmds0wOaJnaMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjZ3JwxCBRpaRVpA3ImXU4/ENcrzp+jsooLVHC7bF5kCGUK0KORaJsds0wOqJseMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjcmN2xCCFPYdMJymqcGoxdDeyuM8t6Kxixfq0PJCyJP71uhYT76NzbmTEICuIj6PMWBK0XH0TqQSTWXj6UWxbhN7Y9jUpXyQ1xxxGpHR5cGWjcGF5";
 		assertThat(stxStr).isEqualTo(goldenStxns);

--- a/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
+++ b/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
@@ -116,13 +116,18 @@ public class TestTemplates {
 
 		// Sign contract
 		DynamicFee.SignedDynamicFee sdf = DynamicFee.SignDynamicFee(program, account1, gh);
+		String encodedLsig = Encoder.encodeToBase64(Encoder.encodeToMsgPack(sdf.lsig));
+		String encodedTxn = Encoder.encodeToBase64(Encoder.encodeToMsgPack(sdf.txn));
+
+		String goldenTxn = "iaNhbXTNE4ilY2xvc2XEIOaalh5vLV96yGYHkmVSvpgjXtMzY8qIkYu5yTipFbb5omZ2zTA5omdoxCB/g7Flf/H8U7ktwYFIodZd/C1LH6PWdyhK3dIAEm2QaaJsds0wOqJseMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjcmN2xCD+vKC7FEpaTqe0OKRoGsgObKEFvLYH/FZTJclWlfaiE6NzbmTEIIU9h0wnKapwajF0N7K4zy3orGLF+rQ8kLIk/vW6FhPvpHR5cGWjcGF5";
+		String goldenLsig = "gqFsxLEBIAUCAYgnuWC6YCYDIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITIOaalh5vLV96yGYHkmVSvpgjXtMzY8qIkYu5yTipFbb5IH+DsWV/8fxTuS3BgUih1l38LUsfo9Z3KErd0gASbZBpMgQiEjMAECMSEDMABzEAEhAzAAgxARIQMRYjEhAxECMSEDEHKBIQMQkpEhAxCCQSEDECJRIQMQQhBBIQMQYqEhCjc2lnxEAhLNdfdDp9Wbi0YwsEQCpP7TVHbHG7y41F4MoESNW/vL1guS+5Wj4f5V9fmM63/VKTSMFidHOSwm5o+pbV5lYH";
+		assertThat(encodedLsig).isEqualTo(goldenLsig);
+		assertThat(encodedTxn).isEqualTo(goldenTxn);
 
 		// Generate signed transactions (using data that would be passed to another person).
-		byte[] signedLsig = Encoder.encodeToMsgPack(sdf.lsig);
-		byte[] txn = Encoder.encodeToMsgPack(sdf.txn);
 		List<SignedTransaction> stxns = DynamicFee.MakeReimbursementTransactions(
-				Encoder.decodeFromMsgPack(txn, Transaction.class),
-				Encoder.decodeFromMsgPack(signedLsig, LogicsigSignature.class),
+				Encoder.decodeFromMsgPack(encodedTxn, Transaction.class),
+				Encoder.decodeFromMsgPack(encodedLsig, LogicsigSignature.class),
 				account2,
 				1234);
 

--- a/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
+++ b/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
@@ -84,4 +84,62 @@ public class TestTemplates {
 		SignedTransaction stx = PeriodicPayment.MakeWithdrawalTransaction(result, 1210, genesisHash);
 		assertThat(Encoder.encodeToMsgPack(stx)).isEqualTo(Encoder.decodeFromBase64(goldenWithdrawalTransaction));
 	}
+
+	@Test
+	public void testDynamicFee() throws Exception {
+
+		String goldenAddress = "GCI4WWDIWUFATVPOQ372OZYG52EULPUZKI7Y34MXK3ZJKIBZXHD2H5C5TI";
+		// algotmpl -d ${GOPATH}/src/github.com/algorand/go-algorand/tools/teal/templates/ dynamic-fee --amt 5000 --cls 42NJMHTPFVPXVSDGA6JGKUV6TARV5UZTMPFIREMLXHETRKIVW34QFSDFRE --to 726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM --fv 12345 --lv 12346 --lease "f4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGk="
+		String golden = "ASAFAgGIJ7lgumAmAyD+vKC7FEpaTqe0OKRoGsgObKEFvLYH/FZTJclWlfaiEyDmmpYeby1feshmB5JlUr6YI17TM2PKiJGLuck4qRW2+SB/g7Flf/H8U7ktwYFIodZd/C1LH6PWdyhK3dIAEm2QaTIEIhIzABAjEhAzAAcxABIQMwAIMQESEDEWIxIQMRAjEhAxBygSEDEJKRIQMQgkEhAxAiUSEDEEIQQSEDEGKhIQ";
+
+		// Initialize inputs
+		Address addr1 = new Address("726KBOYUJJNE5J5UHCSGQGWIBZWKCBN4WYD7YVSTEXEVNFPWUIJ7TAEOPM");
+		Address addr2 = new Address("42NJMHTPFVPXVSDGA6JGKUV6TARV5UZTMPFIREMLXHETRKIVW34QFSDFRE");
+		byte[] pk1 = Encoder.decodeFromBase64("cv8E0Ln24FSkwDgGeuXKStOTGcze5u8yldpXxgrBxumFPYdMJymqcGoxdDeyuM8t6Kxixfq0PJCyJP71uhYT7w==");
+		byte[] pk2 = Encoder.decodeFromBase64("2qjz96Vj9M6YOqtNlfJUOKac13EHCXyDty94ozCjuwwriI+jzFgStFx9E6kEk1l4+lFsW4Te2PY1KV8kNcccRg==");
+		Account account1 = new Account(pk1);
+		Account account2 = new Account(pk2);
+		Lease lease = new Lease("f4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGk=");
+		Digest gh = new Digest("f4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGk=");
+
+		// Create contract.
+		ContractTemplate program = DynamicFee.MakeDynamicFee(
+				addr1,
+				5000,
+				12345,
+				12346,
+				addr2,
+				lease);
+
+		assertThat(Encoder.encodeToBase64(program.program)).isEqualTo(golden);
+		assertThat(program.address.toString()).isEqualTo(goldenAddress);
+
+		// Sign contract
+		DynamicFee.SignedDynamicFee sdf = DynamicFee.SignDynamicFee(program, account1, gh);
+
+		byte[] signedLsig = Encoder.encodeToMsgPack(sdf.lsig);
+		byte[] txn = Encoder.encodeToMsgPack(sdf.txn);
+
+    /*
+		String goldenLsig = "gqFsxLEBIAUCAYgnuWC6YCYDIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITIOaalh5vLV96yGYHkmVSvpgjXtMzY8qIkYu5yTipFbb5IH+DsWV/8fxTuS3BgUih1l38LUsfo9Z3KErd0gASbZBpMgQiEjMAECMSEDMABzEAEhAzAAgxARIQMRYjEhAxECMSEDEHKBIQMQkpEhAxCCQSEDECJRIQMQQhBBIQMQYqEhCjc2lnxEAhLNdfdDp9Wbi0YwsEQCpP7TVHbHG7y41F4MoESNW/vL1guS+5Wj4f5V9fmM63/VKTSMFidHOSwm5o+pbV5lYH";
+		assertThat(signedLsig).isEqualTo(Encoder.decodeFromBase64(goldenLsig));
+		assertThat(Encoder.encodeToMsgPack(sdf.txn)).isEqualTo(Encoder.decodeFromBase64(goldenTxn));
+    */
+
+		// Generate signed transactions (using data that would be passed to another person).
+		List<SignedTransaction> stxns = DynamicFee.MakeReimbursementTransactions(
+				sdf.txn,
+				sdf.lsig,
+				account2,
+				1234);
+
+		String stxStr = "";
+		for (SignedTransaction stxn : stxns) {
+			stxStr += Encoder.encodeToBase64(Encoder.encodeToMsgPack(stxn));
+		}
+		System.out.println(Encoder.encodeToBase64(Encoder.encodeToMsgPack(stxns.get(0))));
+
+		String goldenStxns = "gqRsc2lngqFsxLEBIAUCAYgnuWC6YCYDIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITIOaalh5vLV96yGYHkmVSvpgjXtMzY8qIkYu5yTipFbb5IH+DsWV/8fxTuS3BgUih1l38LUsfo9Z3KErd0gASbZBpMgQiEjMAECMSEDMABzEAEhAzAAgxARIQMRYjEhAxECMSEDEHKBIQMQkpEhAxCCQSEDECJRIQMQQhBBIQMQYqEhCjc2lnxEAhLNdfdDp9Wbi0YwsEQCpP7TVHbHG7y41F4MoESNW/vL1guS+5Wj4f5V9fmM63/VKTSMFidHOSwm5o+pbV5lYHo3R4boujYW10zROIpWNsb3NlxCDmmpYeby1feshmB5JlUr6YI17TM2PKiJGLuck4qRW2+aNmZWXOAAWq6qJmds0wOaJnaMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjZ3JwxCBRpaRVpA3ImXU4/ENcrzp+jsooLVHC7bF5kCGUK0KORaJsds0wOqJseMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjcmN2xCD+vKC7FEpaTqe0OKRoGsgObKEFvLYH/FZTJclWlfaiE6NzbmTEIIU9h0wnKapwajF0N7K4zy3orGLF+rQ8kLIk/vW6FhPvpHR5cGWjcGF5gqNzaWfEQAilsGaC4M4zfYN5QpvREdHEC0DjI2ZWCXSIwwyUWHg2dzd5gKR2Cqu+iUmiCU1hOTTiOump3PILTgWeG0ZkUAajdHhuiqNhbXTOAAWq6qNmZWXOAATzvqJmds0wOaJnaMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjZ3JwxCBRpaRVpA3ImXU4/ENcrzp+jsooLVHC7bF5kCGUK0KORaJsds0wOqJseMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjcmN2xCCFPYdMJymqcGoxdDeyuM8t6Kxixfq0PJCyJP71uhYT76NzbmTEICuIj6PMWBK0XH0TqQSTWXj6UWxbhN7Y9jUpXyQ1xxxGpHR5cGWjcGF5";
+		assertThat(stxStr).isEqualTo(goldenStxns);
+	}
 }

--- a/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
+++ b/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
@@ -125,18 +125,13 @@ public class TestTemplates {
 		assertThat(encodedTxn).isEqualTo(goldenTxn);
 
 		// Generate signed transactions (using data that would be passed to another person).
-		List<SignedTransaction> stxns = DynamicFee.MakeReimbursementTransactions(
+		byte[] stxns = DynamicFee.MakeReimbursementTransactions(
 				Encoder.decodeFromMsgPack(encodedTxn, Transaction.class),
 				Encoder.decodeFromMsgPack(encodedLsig, LogicsigSignature.class),
 				account2,
 				1234);
 
-		String stxStr = "";
-		for (SignedTransaction stxn : stxns) {
-			stxStr += Encoder.encodeToBase64(Encoder.encodeToMsgPack(stxn));
-		}
-
 		String goldenStxns = "gqRsc2lngqFsxLEBIAUCAYgnuWC6YCYDIP68oLsUSlpOp7Q4pGgayA5soQW8tgf8VlMlyVaV9qITIOaalh5vLV96yGYHkmVSvpgjXtMzY8qIkYu5yTipFbb5IH+DsWV/8fxTuS3BgUih1l38LUsfo9Z3KErd0gASbZBpMgQiEjMAECMSEDMABzEAEhAzAAgxARIQMRYjEhAxECMSEDEHKBIQMQkpEhAxCCQSEDECJRIQMQQhBBIQMQYqEhCjc2lnxEAhLNdfdDp9Wbi0YwsEQCpP7TVHbHG7y41F4MoESNW/vL1guS+5Wj4f5V9fmM63/VKTSMFidHOSwm5o+pbV5lYHo3R4boujYW10zROIpWNsb3NlxCDmmpYeby1feshmB5JlUr6YI17TM2PKiJGLuck4qRW2+aNmZWXOAAWq6qJmds0wOaJnaMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjZ3JwxCBRpaRVpA3ImXU4/ENcrzp+jsooLVHC7bF5kCGUK0KORaJsds0wOqJseMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjcmN2xCD+vKC7FEpaTqe0OKRoGsgObKEFvLYH/FZTJclWlfaiE6NzbmTEIIU9h0wnKapwajF0N7K4zy3orGLF+rQ8kLIk/vW6FhPvpHR5cGWjcGF5gqNzaWfEQAilsGaC4M4zfYN5QpvREdHEC0DjI2ZWCXSIwwyUWHg2dzd5gKR2Cqu+iUmiCU1hOTTiOump3PILTgWeG0ZkUAajdHhuiqNhbXTOAAWq6qNmZWXOAATzvqJmds0wOaJnaMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjZ3JwxCBRpaRVpA3ImXU4/ENcrzp+jsooLVHC7bF5kCGUK0KORaJsds0wOqJseMQgf4OxZX/x/FO5LcGBSKHWXfwtSx+j1ncoSt3SABJtkGmjcmN2xCCFPYdMJymqcGoxdDeyuM8t6Kxixfq0PJCyJP71uhYT76NzbmTEICuIj6PMWBK0XH0TqQSTWXj6UWxbhN7Y9jUpXyQ1xxxGpHR5cGWjcGF5";
-		assertThat(stxStr).isEqualTo(goldenStxns);
+		assertThat(Encoder.encodeToBase64(stxns)).isEqualTo(goldenStxns);
 	}
 }

--- a/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
+++ b/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
@@ -128,8 +128,8 @@ public class TestTemplates {
 
 		// Generate signed transactions (using data that would be passed to another person).
 		List<SignedTransaction> stxns = DynamicFee.MakeReimbursementTransactions(
-				sdf.txn,
-				sdf.lsig,
+				Encoder.decodeFromMsgPack(txn, Transaction.class),
+				Encoder.decodeFromMsgPack(signedLsig, LogicsigSignature.class),
 				account2,
 				1234);
 


### PR DESCRIPTION
Implementation of the DynamicFee template. This code has a workaround for the inconsistent fee initialization in order for the golden to match those used by the other SDKs. A followup PR will be made to fix the fee initialization issue because those changes will break many of the existing unit tests.