### PR TITLE
Remove duplicate 'jsonSerializeDeserializeCheck' methods

### DIFF
--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.account;
 
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/com/algorand/algosdk/auction/Bid.java
+++ b/src/main/java/com/algorand/algosdk/auction/Bid.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.math.BigInteger;
-import java.util.Objects;
 
 /**
  * A raw serializable Bid class.

--- a/src/main/java/com/algorand/algosdk/crypto/Address.java
+++ b/src/main/java/com/algorand/algosdk/crypto/Address.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.crypto;
 
-
 import com.algorand.algosdk.util.CryptoProvider;
 import com.algorand.algosdk.util.Digester;
 import com.algorand.algosdk.util.Encoder;
@@ -22,8 +21,6 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import java.io.IOException;
-
-
 
 /**
  * Address represents a serializable 32-byte length Algorand address.

--- a/src/main/java/com/algorand/algosdk/crypto/Digest.java
+++ b/src/main/java/com/algorand/algosdk/crypto/Digest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * A serializable class representing a SHA512-256 Digest

--- a/src/main/java/com/algorand/algosdk/crypto/Ed25519PublicKey.java
+++ b/src/main/java/com/algorand/algosdk/crypto/Ed25519PublicKey.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * a serializable Ed25519PublicKey

--- a/src/main/java/com/algorand/algosdk/crypto/MultisigAddress.java
+++ b/src/main/java/com/algorand/algosdk/crypto/MultisigAddress.java
@@ -1,10 +1,7 @@
 package com.algorand.algosdk.crypto;
 
 import com.algorand.algosdk.util.Digester;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.*;
 
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -28,11 +25,10 @@ public class MultisigAddress implements Serializable {
 
     private static final byte[] PREFIX = "MultisigAddr".getBytes(StandardCharsets.UTF_8);
 
-    @JsonCreator
     public MultisigAddress(
-            @JsonProperty("version") int version,
-            @JsonProperty("threshold") int threshold,
-            @JsonProperty("publicKeys") List<Ed25519PublicKey> publicKeys
+            int version,
+            int threshold,
+            List<Ed25519PublicKey> publicKeys
     ) {
         this.version = version;
         this.threshold = threshold;
@@ -51,7 +47,30 @@ public class MultisigAddress implements Serializable {
         }
     }
 
-    // building an address object helps us generate string representations
+    // workaround for nested JsonValue classes
+    @JsonCreator
+    private MultisigAddress(
+            @JsonProperty("publicKeys") List<byte[]> publicKeys,
+            @JsonProperty("version")  int version,
+            @JsonProperty("threshold") int threshold
+    ) {
+        this(version, threshold, toKeys(publicKeys));
+    }
+
+    // Helper to convert list of byte[]s to list of Ed25519PublicKeys
+    private static List<Ed25519PublicKey> toKeys(List<byte[]> keys) {
+        List<Ed25519PublicKey> ret = new ArrayList<>();
+        for (byte[] key : keys) {
+            ret.add(new Ed25519PublicKey(key));
+        }
+        return ret;
+    }
+
+    /**
+     * Convert into an address to more easily represent as a string.
+     * @return
+     * @throws NoSuchAlgorithmException
+     */
     public Address toAddress() throws NoSuchAlgorithmException {
         int numPkBytes = Ed25519PublicKey.KEY_LEN_BYTES * this.publicKeys.size();
         byte[] hashable = new byte[PREFIX.length + 2 + numPkBytes];
@@ -84,9 +103,10 @@ public class MultisigAddress implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MultisigAddress that = (MultisigAddress) o;
+
         return version == that.version &&
                 threshold == that.threshold &&
-                Objects.equals(publicKeys, that.publicKeys);
+                publicKeys.equals(that.publicKeys);
     }
 
     @Override

--- a/src/main/java/com/algorand/algosdk/crypto/ParticipationPublicKey.java
+++ b/src/main/java/com/algorand/algosdk/crypto/ParticipationPublicKey.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * A serializable class representing a participation key.

--- a/src/main/java/com/algorand/algosdk/crypto/VRFPublicKey.java
+++ b/src/main/java/com/algorand/algosdk/crypto/VRFPublicKey.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * A serializable representation of a VRF public key.

--- a/src/main/java/com/algorand/algosdk/logic/Logic.java
+++ b/src/main/java/com/algorand/algosdk/logic/Logic.java
@@ -5,7 +5,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.Arrays;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/src/main/java/com/algorand/algosdk/templates/ContractTemplate.java
+++ b/src/main/java/com/algorand/algosdk/templates/ContractTemplate.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.algorand.algosdk.templates;
 
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
+++ b/src/main/java/com/algorand/algosdk/templates/DynamicFee.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 

--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.transaction;
 
-
 import com.algorand.algosdk.account.Account;
 import com.algorand.algosdk.crypto.Address;
 import com.algorand.algosdk.crypto.Digest;

--- a/src/main/java/com/algorand/algosdk/transaction/TxGroup.java
+++ b/src/main/java/com/algorand/algosdk/transaction/TxGroup.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.transaction;
 
-
 import com.algorand.algosdk.crypto.Address;
 import com.algorand.algosdk.crypto.Digest;
 import com.algorand.algosdk.util.Digester;
@@ -13,7 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
-
 
 /**
  * TxGroup exports computeGroupID and assignGroupID functions

--- a/src/main/java/com/algorand/algosdk/util/AlgoConverter.java
+++ b/src/main/java/com/algorand/algosdk/util/AlgoConverter.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.util;
 
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 

--- a/src/main/java/com/algorand/algosdk/util/Encoder.java
+++ b/src/main/java/com/algorand/algosdk/util/Encoder.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.util;
 
-import com.algorand.algosdk.crypto.LogicsigSignature;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/src/main/java/com/algorand/algosdk/util/Encoder.java
+++ b/src/main/java/com/algorand/algosdk/util/Encoder.java
@@ -1,5 +1,6 @@
 package com.algorand.algosdk.util;
 
+import com.algorand.algosdk.crypto.LogicsigSignature;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -74,6 +75,17 @@ public class Encoder {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
         return objectMapper.writeValueAsString(o);
+    }
+
+    /**
+     * Encode an object as json.
+     * @param o object to encode
+     * @return json string
+     * @throws JsonProcessingException error
+     */
+    public static <T> T decodeFromJson(String input, Class<T> tClass) throws IOException {
+        ObjectMapper om = new ObjectMapper();
+        return om.readerFor(tClass).readValue(input);
     }
 
     /**

--- a/src/test/java/com/algorand/algosdk/account/TestAccount.java
+++ b/src/test/java/com/algorand/algosdk/account/TestAccount.java
@@ -41,7 +41,6 @@ public class TestAccount {
                 new Digest()
         );
         byte[] seed = Mnemonic.toKey(FROM_SK);
-        System.out.println(Encoder.encodeToJson(tx));
         Account account = new Account(seed);
         // make sure public key generated from mnemonic is correct
         assertThat(new Address(account.getClearTextPublicKey()).toString()).isEqualTo(FROM_ADDR);
@@ -50,7 +49,6 @@ public class TestAccount {
 
         // sign the transaction
         SignedTransaction signedTx = account.signTransaction(tx);
-        System.out.println(Encoder.encodeToJson(signedTx));
 
         byte[] signedTxBytes = Encoder.encodeToMsgPack(signedTx);
         String signedTxHex = Encoder.encodeToHexStr(signedTxBytes);
@@ -80,7 +78,6 @@ public class TestAccount {
                 "",
                 new Digest()
         );
-        System.out.println(Encoder.encodeToJson(tx));
         byte[] seed = Mnemonic.toKey(FROM_SK);
         Account account = new Account(seed);
         // make sure public key generated from mnemonic is correct

--- a/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
@@ -1,7 +1,6 @@
 package com.algorand.algosdk.crypto;
 
 import com.algorand.algosdk.util.TestUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
@@ -1,5 +1,6 @@
 package com.algorand.algosdk.crypto;
 
+import com.algorand.algosdk.util.TestUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
@@ -71,7 +72,7 @@ public class TestLogicsigSignature {
         lsig = new LogicsigSignature(program);
         verified = lsig.verify(sender);
         assertThat(verified).isFalse();
-        jsonSerializeDeserializeCheck(lsig);
+        TestUtil.serializeDeserializeCheck(lsig);
     }
 
     @Test
@@ -110,7 +111,7 @@ public class TestLogicsigSignature {
         byte[] outBytes = Encoder.encodeToMsgPack(lsig);
         LogicsigSignature lsig1 = Encoder.decodeFromMsgPack(outBytes, LogicsigSignature.class);
         assertThat(lsig1).isEqualTo(lsig);
-        jsonSerializeDeserializeCheck(lsig);
+        TestUtil.serializeDeserializeCheck(lsig);
     }
 
     @Test
@@ -182,22 +183,6 @@ public class TestLogicsigSignature {
         assertThat(lsig2).isEqualTo(lsig);
         verified = lsig2.verify(ma.toAddress());
         assertThat(verified).isTrue();
-        jsonSerializeDeserializeCheck(lsig2);
-    }
-
-    private static void jsonSerializeDeserializeCheck(LogicsigSignature lsig) {
-        String encoded, encoded2;
-        try {
-            encoded = Encoder.encodeToJson(lsig);
-            ObjectMapper om = new ObjectMapper();
-            LogicsigSignature decodedLogicSignature = om.readerFor(lsig.getClass()).readValue(encoded.getBytes());
-            assertThat(decodedLogicSignature).isEqualTo(lsig);
-            encoded2 = Encoder.encodeToJson(decodedLogicSignature);
-            assertThat(encoded2).isEqualTo(encoded);
-            LogicsigSignature decodedLogicSignature2 = om.readerFor(lsig.getClass()).readValue(encoded2.getBytes());
-            assertThat(decodedLogicSignature2).isEqualTo(decodedLogicSignature);
-        } catch (Exception e) {
-            fail("Should not have thrown an exception.", e);
-        }
+        TestUtil.serializeDeserializeCheck(lsig2);
     }
 }

--- a/src/test/java/com/algorand/algosdk/crypto/TestMultisigAddress.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestMultisigAddress.java
@@ -1,9 +1,6 @@
 package com.algorand.algosdk.crypto;
 
-import com.algorand.algosdk.util.Encoder;
 import com.algorand.algosdk.util.TestUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/src/test/java/com/algorand/algosdk/crypto/TestMultisigAddress.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestMultisigAddress.java
@@ -1,6 +1,7 @@
 package com.algorand.algosdk.crypto;
 
 import com.algorand.algosdk.util.Encoder;
+import com.algorand.algosdk.util.TestUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -23,23 +24,6 @@ public class TestMultisigAddress {
         ));
 
         assertThat(addr.toString()).isEqualTo("UCE2U2JC4O4ZR6W763GUQCG57HQCDZEUJY4J5I6VYY4HQZUJDF7AKZO5GM");
-        jsonSerializeDeserializeCheck(addr);
-    }
-
-    private static void jsonSerializeDeserializeCheck(MultisigAddress msig) {
-        String encoded, encoded2;
-        try {
-            encoded = Encoder.encodeToJson(msig);
-            ObjectMapper om = new ObjectMapper();
-            MultisigAddress multisigAddress1 = om.readerFor(msig.getClass()).readValue(encoded.getBytes());
-            assertThat(multisigAddress1).isEqualTo(msig);
-            encoded2 = Encoder.encodeToJson(multisigAddress1);
-            assertThat(encoded2).isEqualToIgnoringWhitespace(encoded);
-            MultisigAddress multisigAddress2 = om.readerFor(msig.getClass()).readValue(encoded2.getBytes());
-            Assert.assertEquals(multisigAddress1, multisigAddress2);
-            assertThat(multisigAddress2).isEqualTo(multisigAddress1);
-        } catch (Exception e) {
-            fail("Should not throw an exception.", e);
-        }
+        TestUtil.serializeDeserializeCheck(addr);
     }
 }

--- a/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
+++ b/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.templates;
 
-
 import com.algorand.algosdk.account.Account;
 import com.algorand.algosdk.crypto.Address;
 import com.algorand.algosdk.crypto.Digest;
@@ -14,7 +13,6 @@ import org.junit.Test;
 import com.algorand.algosdk.util.Encoder;
 
 import static org.assertj.core.api.Assertions.*;
-
 
 public class TestTemplates {
 

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -8,6 +8,7 @@ import com.algorand.algosdk.crypto.MultisigSignature;
 import com.algorand.algosdk.crypto.LogicsigSignature;
 import com.algorand.algosdk.mnemonic.Mnemonic;
 import com.algorand.algosdk.util.Encoder;
+import com.algorand.algosdk.util.TestUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
@@ -131,7 +132,7 @@ public class TestTransaction {
         assertThat(decodedOut).isEqualTo(stx);
         assertThat(encodedOut).isEqualTo(goldenString);
         assertThat(decodedOut).isEqualTo(stx);
-        assertThat(jsonSerializeDeserializeCheck(stx)).isTrue();
+        TestUtil.serializeDeserializeCheck(stx);
     }
 
     @Test
@@ -234,7 +235,7 @@ public class TestTransaction {
 
         assertThat(encodedOutBytes).isEqualTo(goldenString);
         assertThat(o).isEqualTo(stx);
-        assertThat(jsonSerializeDeserializeCheck(stx)).isTrue();
+        TestUtil.serializeDeserializeCheck(stx);
     }
 
     @Test
@@ -323,7 +324,7 @@ public class TestTransaction {
 
         assertThat(encodedOutBytes).isEqualTo(goldenString);
         assertThat(o).isEqualTo(stx);
-        assertThat(jsonSerializeDeserializeCheck(stx)).isTrue();
+        TestUtil.serializeDeserializeCheck(stx);
     }
 
     @Test
@@ -368,7 +369,7 @@ public class TestTransaction {
         SignedTransaction stxDecoded = Encoder.decodeFromMsgPack(encodedOutBytes, SignedTransaction.class);
         assertThat(stxDecoded).isEqualTo(stx);
         assertThat(encodedOutBytes).isEqualTo(goldenString);
-        assertThat(jsonSerializeDeserializeCheck(stx)).isTrue();
+        TestUtil.serializeDeserializeCheck(stx);
     }
 
     @Test
@@ -408,8 +409,8 @@ public class TestTransaction {
 
         assertThat(Encoder.encodeToBase64(Encoder.encodeToMsgPack(stx1))).isEqualTo(goldenTx1);
         assertThat(Encoder.encodeToBase64(Encoder.encodeToMsgPack(stx2))).isEqualTo(goldenTx2);
-        assertThat(jsonSerializeDeserializeCheck(stx1)).isTrue();
-        assertThat(jsonSerializeDeserializeCheck(stx2)).isTrue();
+        TestUtil.serializeDeserializeCheck(stx1);
+        TestUtil.serializeDeserializeCheck(stx2);
 
 
         Digest gid = TxGroup.computeGroupID(tx1, tx2);
@@ -503,7 +504,7 @@ public class TestTransaction {
         SignedTransaction stxDecoded = Encoder.decodeFromMsgPack(encodedOutBytes, SignedTransaction.class);
         assertThat(stxDecoded).isEqualTo(stx);
         assertThat(encodedOutBytes).isEqualTo(goldenString);
-        assertThat(jsonSerializeDeserializeCheck(stx)).isTrue();
+        TestUtil.serializeDeserializeCheck(stx);
     }
 
 
@@ -565,7 +566,7 @@ public class TestTransaction {
 
         assertThat(stxDecoded).isEqualTo(stx);
         assertThat(encodedOutBytes).isEqualTo(goldenString);
-        assertThat(jsonSerializeDeserializeCheck(stx)).isTrue();
+        TestUtil.serializeDeserializeCheck(stx);
     }
 
     @Test
@@ -608,7 +609,7 @@ public class TestTransaction {
 
         assertThat(stxDecoded).isEqualTo(stx);
         assertThat(encodedOutBytes).isEqualTo(goldenString);
-        assertThat(jsonSerializeDeserializeCheck(stx)).isTrue();
+        TestUtil.serializeDeserializeCheck(stx);
     }
 
     @Test
@@ -680,19 +681,6 @@ public class TestTransaction {
 
         assertThat(stxDecoded).isEqualTo(stx);
         assertThat(encodedOutBytes).isEqualTo(goldenString);
-        assertThat(jsonSerializeDeserializeCheck(stx)).isTrue();
-    }
-
-    private static boolean jsonSerializeDeserializeCheck(SignedTransaction tx) {
-        String encoded, encoded2;
-        try {
-            encoded = Encoder.encodeToJson(tx);
-            ObjectMapper om = new ObjectMapper();
-            SignedTransaction decodedTx = om.readerFor(tx.getClass()).readValue(encoded.getBytes());
-            encoded2 = Encoder.encodeToJson(decodedTx);
-        } catch (Exception e) {
-            return false;
-        }
-        return encoded.contentEquals(encoded2);
+        TestUtil.serializeDeserializeCheck(stx);
     }
 }

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -9,7 +9,6 @@ import com.algorand.algosdk.crypto.LogicsigSignature;
 import com.algorand.algosdk.mnemonic.Mnemonic;
 import com.algorand.algosdk.util.Encoder;
 import com.algorand.algosdk.util.TestUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Test;
 
@@ -20,7 +19,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.*;
-
 
 public class TestTransaction {
     private static Account DEFAULT_ACCOUNT = initializeDefaultAccount();

--- a/src/test/java/com/algorand/algosdk/util/TestUtil.java
+++ b/src/test/java/com/algorand/algosdk/util/TestUtil.java
@@ -1,0 +1,47 @@
+package com.algorand.algosdk.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class TestUtil {
+    public static void serializeDeserializeCheck(Object object) {
+        jsonSerializeTests(object);
+        messagePackSerializeTests(object);
+    }
+
+    private static void jsonSerializeTests(Object object) {
+        String encoded, encoded2;
+        Object decoded, decoded2;
+        try {
+            encoded = Encoder.encodeToJson(object);
+            decoded = Encoder.decodeFromJson(encoded, object.getClass());
+            assertThat(decoded).isEqualTo(object);
+
+            encoded2 = Encoder.encodeToJson(decoded);
+            assertThat(encoded2).isEqualTo(encoded);
+
+            decoded2 = Encoder.decodeFromJson(encoded2, decoded.getClass());
+            assertThat(decoded2).isEqualTo(decoded);
+        } catch (Exception e) {
+            fail("Should not have thrown an exception.", e);
+        }
+    }
+
+    private static void messagePackSerializeTests(Object object) {
+        String encoded, encoded2;
+        Object decoded, decoded2;
+        try {
+            encoded = Encoder.encodeToBase64(Encoder.encodeToMsgPack(object));
+            decoded = Encoder.decodeFromMsgPack(encoded, object.getClass());
+            assertThat(decoded).isEqualTo(object);
+
+            encoded2 = Encoder.encodeToBase64(Encoder.encodeToMsgPack(decoded));
+            assertThat(encoded2).isEqualTo(encoded);
+
+            decoded2 = Encoder.decodeFromMsgPack(encoded2, decoded.getClass());
+            assertThat(decoded2).isEqualTo(decoded);
+        } catch (Exception e) {
+            fail("Should not have thrown an exception.", e);
+        }
+    }
+}


### PR DESCRIPTION
Replace duplicate json encoding test methods with a single method which also tests the msgpack encoding.

Fix a bug that was uncovered by these tests.