### PR TITLE
Use JUnit5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,21 +102,25 @@ cryptographic packages for updates or alternative implementations.
 
 This project uses Maven.
 
-To build:
+**To build**
 ```
 mvn package
 ```
 
-To run the example project, run the following command in the examples
-directory, be sure to update your algod network address and the API token
+**To run the example project**
+Use the following command in the examples directory, be sure to update your algod network address and the API token
 parameters (see examples/README for more information):
 ```
 mvn exec:java -Dexec.mainClass="com.algorand.algosdk.example.Main" -Dexec.args="127.0.0.1:8080 ***X-Algo-API-Token***"
 ```
 
-To test:
+**To test**
+We are using separate version targets for production and testing to allow using JUnit5 for tests. Some IDEs, like IDEA
+do not support this very well. To workaround the issue a special `ide` profile should be enabled if your IDE does not
+support mixed `target` and `testTarget` versions. Regardless of IDE support, the tests can be run from the command line.
+In this case `clean` is used in case an incremental build was made by the IDE with Java8.
 ```
-mvn test
+mvn clean test
 ```
 
 ## deploying artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,13 @@
     </developers>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <junit5.version>5.5.2</junit5.version>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+
+        <!-- Test sources at 1.8 to allow using JUnit5 -->
+        <java.version>1.7</java.version>
+        <java.test.version>1.8</java.test.version>
+
         <!-- github server corresponds to entry in ~/.m2/settings.xml -->
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -125,6 +130,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <!-- use 2.9.1 for Java 7 projects -->
@@ -135,7 +158,68 @@
         <!-- end test dependencies -->
     </dependencies>
 
+    <build>
+      <plugins>
+        <!-- Newer version of surefire plugin for running JUnit5 tests. -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M4</version>
+        </plugin>
+      </plugins>
+    </build>
+
     <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven.compiler.plugin.version}</version>
+                        <configuration>
+                          <source>${java.version}</source>
+                            <target>${java.version}</target>
+                            <testSource>${java.test.version}</testSource>
+                            <testTarget>${java.test.version}</testTarget>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- IDE Profile: https://youtrack.jetbrains.com/issue/IDEA-85478#focus=streamItem-27-1994481.0-0 -->
+        <!-- Note: IntelliJ doesn't support different targets: https://youtrack.jetbrains.com/issue/IDEA-85478 -->
+        <!-- Automatically activated when IDEA sets a property, putting this second overrides source/target. -->
+        <profile>
+            <id>ide</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>idea.maven.embedder.version</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven.compiler.plugin.version}</version>
+                        <configuration>
+                            <source>${java.test.version}</source>
+                            <target>${java.test.version}</target>
+                            <testSource>${java.test.version}</testSource>
+                            <testTarget>${java.test.version}</testTarget>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <!--
                 Maven release profile.
@@ -346,5 +430,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>${maven.compiler.plugin.version}</version>
                         <configuration>
-                          <source>${java.version}</source>
+                            <source>${java.version}</source>
                             <target>${java.version}</target>
                             <testSource>${java.test.version}</testSource>
                             <testTarget>${java.test.version}</testTarget>

--- a/pom.xml
+++ b/pom.xml
@@ -124,12 +124,6 @@
 
         <!-- test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit5.version}</version>

--- a/src/test/java/com/algorand/algosdk/account/TestAccount.java
+++ b/src/test/java/com/algorand/algosdk/account/TestAccount.java
@@ -10,7 +10,7 @@ import com.algorand.algosdk.transaction.SignedTransaction;
 import com.algorand.algosdk.transaction.Transaction;
 import com.algorand.algosdk.util.Encoder;
 import com.algorand.algosdk.crypto.Signature;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -20,7 +20,6 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.*;
 
 public class TestAccount {
-
     @Test
     public void testSignsTransactionE2E() throws Exception {
         final String REF_SIG_TXN = "82a3736967c4403f5a5cbc5cb038b0d29a53c0adf8a643822da0e41681bcab050e406fd40af20aa56a2f8c0e05d3bee8d4e8489ef13438151911b31b5ed5b660cac6bae4080507a374786e87a3616d74cd04d2a3666565cd03e8a26676ce0001a04fa26c76ce0001a437a3726376c4207d3f99e53d34ae49eb2f458761cf538408ffdaee35c70d8234166de7abe3e517a3736e64c4201bd63dc672b0bb29d42fcafa3422a4d385c0c8169bb01595babf8855cf596979a474797065a3706179";

--- a/src/test/java/com/algorand/algosdk/crypto/TestAddress.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestAddress.java
@@ -1,6 +1,6 @@
 package com.algorand.algosdk.crypto;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.util.Random;
@@ -8,7 +8,6 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.*;
 
 public class TestAddress {
-
     @Test
     public void testEncodeDecodeStr() throws Exception {
         Random r = new Random();

--- a/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
@@ -1,26 +1,21 @@
 package com.algorand.algosdk.crypto;
 
 import com.algorand.algosdk.util.TestUtil;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
 import com.algorand.algosdk.account.Account;
 import com.algorand.algosdk.util.Encoder;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 
 public class TestLogicsigSignature {
     @Test
     public void testLogicsigEmptyCreation() throws Exception {
-        try {
-            new LogicsigSignature(null, null);
-            fail("Should have thrown a NPE.");
-        } catch (NullPointerException npe) {
-            return;
-        }
-        fail("Should have thrown a NPE.");
+        assertThatThrownBy(() -> new LogicsigSignature(null, null))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -79,13 +74,9 @@ public class TestLogicsigSignature {
         byte[] program = {
             0x02, 0x20, 0x01, 0x01, 0x22
         };
-        try {
-            new LogicsigSignature(program);
-            fail("An IllegalArgumentException should have been thrown.");
-        } catch (IllegalArgumentException e) {
-            return;
-        }
-        fail("An IllegalArgumentException should have been thrown.");
+        assertThatThrownBy(() -> new LogicsigSignature(program))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("unsupported version");
     }
 
     @Test
@@ -132,10 +123,8 @@ public class TestLogicsigSignature {
 
         String mn1 = "auction inquiry lava second expand liberty glass involve ginger illness length room item discover ahead table doctor term tackle cement bonus profit right above catch";
         String mn2 = "since during average anxiety protect cherry club long lawsuit loan expand embark forum theory winter park twenty ball kangaroo cram burst board host ability left";
-        String mn3 = "advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor";
         Account acc1 = new Account(mn1);
         Account acc2 = new Account(mn2);
-        Account acc3 = new Account(mn3);
         Account account = new Account();
 
         LogicsigSignature lsig = new LogicsigSignature(program);
@@ -149,14 +138,10 @@ public class TestLogicsigSignature {
         boolean verified = lsig.verify(ma.toAddress());
         assertThat(verified).isFalse();
 
-        boolean caught = false;
-        try {
-            account.appendToLogicsig(lsig);
-            fail("Should have thrown IllegalArgumentException exception.");
-        } catch(IllegalArgumentException ex) {
-            caught = true;
-        }
-        assertThat(caught).isTrue();
+        LogicsigSignature lsigLambda = lsig;
+        assertThatThrownBy(() -> account.appendToLogicsig(lsigLambda))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Multisig account does not contain this secret key");
 
         lsig = acc2.appendToLogicsig(lsig);
         verified = lsig.verify(ma.toAddress());

--- a/src/test/java/com/algorand/algosdk/crypto/TestMultisigAddress.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestMultisigAddress.java
@@ -1,7 +1,7 @@
 package com.algorand.algosdk.crypto;
 
 import com.algorand.algosdk.util.TestUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 

--- a/src/test/java/com/algorand/algosdk/logic/TestLogic.java
+++ b/src/test/java/com/algorand/algosdk/logic/TestLogic.java
@@ -1,7 +1,7 @@
 package com.algorand.algosdk.logic;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
@@ -9,7 +9,6 @@ import static com.algorand.algosdk.logic.Logic.*;
 import static org.assertj.core.api.Assertions.*;
 
 public class TestLogic {
-
     @Test
     public void testParseUvarint1() throws Exception {
         byte[] data = {0x01};
@@ -122,7 +121,7 @@ public class TestLogic {
         assertThat(programData.byteBlock).isEmpty();
    }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCheckProgramLongArgs() throws Exception {
         byte[] program = {
             0x01, 0x20, 0x01, 0x01, 0x22  // int 1
@@ -133,11 +132,12 @@ public class TestLogic {
         Arrays.fill(arg, (byte)0x31);
         args.add(arg);
 
-        ProgramData programData = readProgram(program, args);
-        assertThat(programData.good).isFalse();
+        assertThatThrownBy(() -> readProgram(program, args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("program too long");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCheckProgramLong() throws Exception {
         byte[] program = {
             0x01, 0x20, 0x01, 0x01, 0x22  // int 1
@@ -148,22 +148,24 @@ public class TestLogic {
 
         System.arraycopy(program, 0, program2, 0, program.length);
         System.arraycopy(int1, 0, program2, program.length, int1.length);
-        boolean valid = checkProgram(program2, args);
-        assertThat(valid).isFalse();
+        assertThatThrownBy(() -> checkProgram(program2, args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("program too long");
    }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCheckProgramInvalidOpcode() throws Exception {
         byte[] program = {
             0x01, 0x20, 0x01, 0x01, (byte)0x81
         };
-        ArrayList<byte[]> args = new ArrayList<byte[]>();
+        ArrayList<byte[]> args = new ArrayList<>();
 
-        boolean valid = checkProgram(program, args);
-        assertThat(valid).isFalse();
+        assertThatThrownBy(() -> checkProgram(program, args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid instruction");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCheckProgramCostly() throws Exception {
         byte[] program = {
             0x01, 0x26, 0x01, 0x01, 0x01, 0x01, 0x28, 0x02  // byte 0x01 + keccak256
@@ -187,7 +189,8 @@ public class TestLogic {
         byte[] program3 = new byte[program.length + keccak256800.length];
         System.arraycopy(program, 0, program3, 0, program.length);
         System.arraycopy(keccak256800, 0, program3, program.length, keccak256800.length);
-        valid = checkProgram(program3, args);
-        assertThat(valid).isFalse();
+        assertThatThrownBy(() -> checkProgram(program3, args))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("program too costly to run");
     }
 }

--- a/src/test/java/com/algorand/algosdk/mnemonic/TestMnemonic.java
+++ b/src/test/java/com/algorand/algosdk/mnemonic/TestMnemonic.java
@@ -1,6 +1,6 @@
 package com.algorand.algosdk.mnemonic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
@@ -9,7 +9,6 @@ import java.util.Random;
 import static org.assertj.core.api.Assertions.*;
 
 public class TestMnemonic {
-
     @Test
     public void testZeroVector() throws Exception {
         byte[] zeroKeys = new byte[32];
@@ -23,13 +22,9 @@ public class TestMnemonic {
     @Test
     public void testWordNotInList() throws Exception {
         String mn = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon zzz invest";
-        try {
-            byte[] keyBytes = Mnemonic.toKey(mn);
-            fail("Expected an IllegalArgumentException.");
-        } catch (IllegalArgumentException e) {
-            return;
-        }
-        fail("Expected an IllegalArgumentException.");
+        assertThatThrownBy(() -> Mnemonic.toKey(mn))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("mnemonic contains word that is not in word list");
     }
 
     @Test
@@ -65,14 +60,9 @@ public class TestMnemonic {
                 s.append(words[j]);
             }
             String corruptedMn = s.toString();
-            try {
-                byte[] recKey = Mnemonic.toKey(corruptedMn);
-                fail("Corrupted checksum should throw a GeneralSecurityException");
-            } catch (GeneralSecurityException e) {
-                // should have failed
-                continue;
-            }
-            fail("Corrupted checksum should throw a GeneralSecurityException");
+            assertThatThrownBy(() -> Mnemonic.toKey(corruptedMn))
+                    .isInstanceOf(GeneralSecurityException.class)
+                    .hasMessage("checksum failed to validate");
         }
     }
 
@@ -85,13 +75,9 @@ public class TestMnemonic {
         for (int badlen: badLengths) {
             byte[] randKey = new byte[badlen];
             r.nextBytes(randKey);
-            try {
-                String mn = Mnemonic.fromKey(randKey);
-                fail("Invalid key length should throw IllegalArgumentException");
-            } catch (IllegalArgumentException e) {
-                continue;
-            }
-            fail("Invalid key length should throw IllegalArgumentException");
+            assertThatThrownBy(() -> Mnemonic.fromKey(randKey))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("key length must be 32 bytes");
         }
     }
 

--- a/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
+++ b/src/test/java/com/algorand/algosdk/templates/TestTemplates.java
@@ -8,15 +8,14 @@ import com.algorand.algosdk.logic.Logic;
 import com.algorand.algosdk.transaction.Lease;
 import com.algorand.algosdk.transaction.SignedTransaction;
 import com.algorand.algosdk.transaction.Transaction;
-import org.junit.Test;
 
 import com.algorand.algosdk.util.Encoder;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 
 public class TestTemplates {
-
-	@Test 
+	@Test
 	public void testVarInt() {
 		int a = 600000;
 		byte[] buffer = Logic.putUVarint((int) a);

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -9,8 +9,7 @@ import com.algorand.algosdk.crypto.LogicsigSignature;
 import com.algorand.algosdk.mnemonic.Mnemonic;
 import com.algorand.algosdk.util.Encoder;
 import com.algorand.algosdk.util.TestUtil;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
 import java.math.BigInteger;
@@ -26,7 +25,7 @@ public class TestTransaction {
     private static Account initializeDefaultAccount() {
         try {
             String mnemonic = "awful drop leaf tennis indoor begin mandate discover uncle seven only coil atom any hospital uncover make any climb actor armed measure need above hundred";
-            return new Account(mnemonic);
+           return new Account(mnemonic);
         } catch (Exception e) {
             fail("Failed to initialize static default account.");
         }
@@ -137,8 +136,6 @@ public class TestTransaction {
     public void testAssetParamsValidation() throws Exception
     {
         Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");
-        byte[] gh = Encoder.decodeFromBase64("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
-        Address sender = addr;
         Address manager = addr;
         Address reserve = addr;
         Address freeze = addr;
@@ -146,46 +143,35 @@ public class TestTransaction {
         String badMetadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyF!";
         String tooLongMetadataHash = "fACPO4nRgO55j1ndAK3W6Sgc4APkcyFhfACPO4nRgO55j1ndAK3W6Sgc4APkcyFh";
 
+        assertThatThrownBy(() -> new Transaction.AssetParams(
+                BigInteger.valueOf(100),
+                3,
+                false,
+                "tst",
+                "testcoin",
+                "website",
+                badMetadataHash.getBytes(StandardCharsets.UTF_8),
+                manager,
+                reserve,
+                freeze,
+                clawback))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("asset metadataHash '" +  badMetadataHash  + "' is not base64 encoded");
 
-        try {
-            Transaction.AssetParams expectedParams = new Transaction.AssetParams(
-                    BigInteger.valueOf(100),
-                    3,
-                    false,
-                    "tst",
-                    "testcoin",
-                    "website",
-                    badMetadataHash.getBytes(StandardCharsets.UTF_8),
-                    manager,
-                    reserve,
-                    freeze,
-                    clawback
-            );
-            fail("expected metadataHash validation failure");
-        }
-        catch( RuntimeException rte) {
-            assertThat(rte.getMessage().contains("asset metadataHash '" +  badMetadataHash  + "' is not base64 encoded")).isTrue();
-        }
-
-        try {
-            Transaction.AssetParams expectedParams = new Transaction.AssetParams(
-                    BigInteger.valueOf(100),
-                    3,
-                    false,
-                    "tst",
-                    "testcoin",
-                    "website",
-                    tooLongMetadataHash.getBytes(StandardCharsets.UTF_8),
-                    manager,
-                    reserve,
-                    freeze,
-                    clawback
-            );
-            fail("expected metadataHash validation failure");
-        }
-        catch( RuntimeException rte) {
-            assertThat(rte.getMessage().contains("asset metadataHash cannot be greater than 32 bytes")).isTrue();
-        }
+        assertThatThrownBy(() -> new Transaction.AssetParams(
+                BigInteger.valueOf(100),
+                3,
+                false,
+                "tst",
+                "testcoin",
+                "website",
+                tooLongMetadataHash.getBytes(StandardCharsets.UTF_8),
+                manager,
+                reserve,
+                freeze,
+                clawback))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("asset metadataHash cannot be greater than 32 bytes");
     }
 
     @Test
@@ -246,9 +232,7 @@ public class TestTransaction {
         Address freeze = addr;
         Address clawback = addr;
 
-        boolean exceptionCaughtNull = false;
-        try {
-        	Transaction.createAssetConfigureTransaction(
+        assertThatThrownBy(() -> Transaction.createAssetConfigureTransaction(
                 sender,
                 BigInteger.valueOf(10),
                 BigInteger.valueOf(322575),
@@ -261,18 +245,11 @@ public class TestTransaction {
                 reserve,
                 new Address(),
                 clawback,
-                true);
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage()).isEqualTo("strict empty address checking "
-        			+ "requested but empty or default address supplied "
-        			+ "to one or more manager addresses");
-        	exceptionCaughtNull = true;
-        }
-        assertThat(exceptionCaughtNull).isTrue();
+                true))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("strict empty address checking requested but empty or default address supplied to one or more manager addresses");
 
-        boolean exceptionCaughtDefault = false;
-        try {
-        	Transaction.createAssetConfigureTransaction(
+        assertThatThrownBy(() -> Transaction.createAssetConfigureTransaction(
                 sender,
                 BigInteger.valueOf(10),
                 BigInteger.valueOf(322575),
@@ -285,14 +262,9 @@ public class TestTransaction {
                 reserve,
                 freeze,
                 null,
-                true);
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage()).isEqualTo("strict empty address checking "
-                    + "requested but empty or default address supplied "
-                    + "to one or more manager addresses");
-        	exceptionCaughtDefault = true;
-        }
-        assertThat(exceptionCaughtDefault).isTrue();
+                true))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("strict empty address checking requested but empty or default address supplied to one or more manager addresses");
     }
 
     @Test
@@ -443,16 +415,18 @@ public class TestTransaction {
         assertThat(result).hasSize(0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testTransactionGroupEmpty() throws IOException {
-        TxGroup.computeGroupID();
-        fail("no expected exception");
+        assertThatThrownBy(() -> TxGroup.computeGroupID())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("empty transaction list");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testTransactionGroupNull() throws IOException {
-        TxGroup.computeGroupID();
-        fail("no expected exception");
+        assertThatThrownBy(() -> TxGroup.computeGroupID())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("empty transaction list");
     }
 
     @Test


### PR DESCRIPTION
This required some build magic to make tests using Java 8, which is required by JUnit5. This has the added benefit of allowing us to use more expressive assertions for exception validation.

It seems to work alright with IntelliJ, but the IDE will think that lambda's are OK, which definitely isn't the case. Anything outside the IDE will properly set the build target, and will fail to compile Java 8 features (assuming they aren't cached, so `mvn clean package` may need to be done).