### PR TITLE
Update Java SDK for indexer integration testing.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,9 @@
-FROM ubuntu:19.10
+FROM adoptopenjdk/maven-openjdk11
 
-RUN if [ ${OSTYPE} = Linux ] && [ ${USER_ID:-0} -ne 0 ] && [ ${GROUP_ID:-0} -ne 0 ]; then \
-    groupadd -g ${GROUP_ID} algorand &&\
-    useradd -l -u ${USER_ID} -g algorand algorand &&\
-    chown --changes --silent --no-dereference --recursive \
-          --from=33:33 ${USER_ID}:${GROUP_ID} \
-        /opt \
-;fi
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Basic dependencies
-ENV HOME /opt
-RUN apt-get update && apt-get install -y apt-utils curl git git-core bsdmainutils
-
-# Install python dependencies
-ENV PYENV_ROOT $HOME/pyenv
-ENV PATH $PYENV_ROOT/bin:$PATH
-RUN apt-get install -y curl gcc make zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libssl-dev libffi-dev
-RUN git clone https://github.com/pyenv/pyenv.git $HOME/pyenv
-
-RUN eval "$(pyenv init -)" && \
-    pyenv install 3.7.1 && \
-    pyenv global 3.7.1 && \
-    pip install --upgrade pip && \
-    pyenv rehash
-ENV PATH=$PYENV_ROOT/shims:$PATH
-
-# Install Java dependencies
-RUN apt-get install -y maven default-jdk
-
-# Install Go dependencies
-ARG GOLANG_VERSION=1.13.8
-RUN curl https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz -o $HOME/go.tar.gz
-RUN tar -xvf $HOME/go.tar.gz -C /usr/local
-ENV GOROOT /usr/local/go
-ENV GOPATH $HOME/go
-ENV PATH $GOROOT/bin:$PATH
-
-# Install algorand-sdk-testing script dependencies
-RUN pip3 install gitpython
-
+# Copy SDK code into the container
 RUN mkdir -p $HOME/java-algorand-sdk
+COPY . $HOME/java-algorand-sdk
 WORKDIR $HOME/java-algorand-sdk
-CMD ["/bin/bash", "-c", "GO111MODULE=off && temp/docker/setup.py --algod-config temp/config_future && temp/docker/test.py --algod-config temp/config_future --network-dir /opt/testnetwork"]
+
+# Run integration tests
+CMD ["/bin/bash", "-c", "mvn test -Dskip.integration.tests=false -e"]

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -5,20 +5,22 @@ set -e
 rootdir=`dirname $0`
 pushd $rootdir
 
-# get feature files from algorand-sdk-testing repo
-sudo rm -rf temp
-git clone --single-branch --branch templates https://github.com/algorand/algorand-sdk-testing.git temp
+# Reset test harness
+rm -rf test-harness
+git clone --single-branch --branch will/indexer https://github.com/algorand/algorand-sdk-testing.git test-harness
 
-# Install the sdk.py driver
-cp sdk.py temp/docker
-# Copy feature files into the project resources
+## Copy feature files into the project resources
 mkdir -p src/test/resources/com/algorand/algosdk/integration
-cp temp/features/integration/* src/test/resources/com/algorand/algosdk/integration
-cp temp/features/offline.feature src/test/resources/com/algorand/algosdk/integration
+cp test-harness/features/integration/* src/test/resources/com/algorand/algosdk/integration
+cp test-harness/features/offline.feature src/test/resources/com/algorand/algosdk/integration
 
-# Build and execute the docker container
-docker build -t sdk-testing -f Dockerfile "$(pwd)"
+# Build SDK testing environment
+docker build -t java-sdk-testing -f Dockerfile "$(pwd)"
+
+# Start test harness environment
+./test-harness/scripts/up.sh
+
+# Launch SDK testing
 docker run -it \
-     -v "$(pwd)":/opt/java-algorand-sdk \
-     sdk-testing:latest 
-
+     --network host \
+     java-sdk-testing:latest 

--- a/src/test/java/com/algorand/algosdk/integration/Stepdefs.java
+++ b/src/test/java/com/algorand/algosdk/integration/Stepdefs.java
@@ -54,6 +54,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class Stepdefs {
+    public static String token = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    public static Integer algodPort = 60000;
+    public static Integer kmdPort = 60001;
+
     TransactionParams params;
     SignedTransaction stx;
     SignedTransaction[] stxs;
@@ -559,39 +563,24 @@ public class Stepdefs {
 
     @Given("a kmd client")
     public void kClient() throws FileNotFoundException, IOException, NoSuchAlgorithmException{
-        String data_dir_path = System.getenv("NODE_DIR") + "/";
-        data_dir_path += System.getenv("KMD_DIR") + "/";
-        BufferedReader reader = new BufferedReader(new FileReader(data_dir_path + "kmd.token"));
-        String kmdToken = reader.readLine();
-        reader.close();
-        reader = new BufferedReader(new FileReader(data_dir_path + "kmd.net"));
-        String kmdAddress = reader.readLine();
         kmdClient = new KmdClient();
         kmdClient.setConnectTimeout(30000);
         kmdClient.setReadTimeout(30000);
         kmdClient.setWriteTimeout(30000);
-        kmdClient.setApiKey(kmdToken);
-        kmdClient.setBasePath("http://" + kmdAddress);
+        kmdClient.setApiKey(token);
+        kmdClient.setBasePath("http://localhost:" + kmdPort);
         kcl = new KmdApi(kmdClient);
-
     }
 
     @Given("an algod client")
     public void aClient() throws FileNotFoundException, IOException{
-        String data_dir_path = System.getenv("NODE_DIR") + "/";
-        BufferedReader reader = new BufferedReader(new FileReader(data_dir_path + "algod.token"));
-        String algodToken = reader.readLine();
-        reader.close();
-        reader = new BufferedReader(new FileReader(data_dir_path + "algod.net"));
-        String algodAddress = reader.readLine();
         algodClient = new AlgodClient();
         algodClient.setConnectTimeout(30000);
         algodClient.setReadTimeout(30000);
         algodClient.setWriteTimeout(30000);
-        algodClient.setApiKey(algodToken);
-        algodClient.setBasePath("http://" + algodAddress);
+        algodClient.setApiKey(token);
+        algodClient.setBasePath("http://localhost:" + algodPort);
         acl = new AlgodApi(algodClient);
-
     }
 
     @Given("wallet information")


### PR DESCRIPTION
Support for the new cucumber with indexer environment.

Changes:
1. Connection information is now static, update SDK to use hard coded token + ports.
2. Docker container only needs to build + run the SDK, so it is greatly simplified (and can leverage an off the shelf container if one exists).
3. The driver script stays mostly the same, but now calls `./scripts/up.sh` to start the test environment, and launches its own container with `--network host` so that it can use `localhost:<port>` in the tests.