### PR TITLE
Finish the rekey integration test and remove the run-order requirement.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ unit:
 	mvn test -Dcucumber.filter.tags="@unit.offline or @unit.algod or @unit.indexer or @unit.rekey"
 
 integration:
-	mvn test -Dcucumber.filter.tags="@algod or @assets or @auction or @kmd or @send or @template or @indexer"
-	mvn test -Dcucumber.filter.tags="@rekey"
+	mvn test -Dcucumber.filter.tags="@algod or @assets or @auction or @kmd or @send or @template or @indexer or @rekey"
 docker-test:
 	./run_integration_tests.sh

--- a/src/test/java/com/algorand/algosdk/integration/Stepdefs.java
+++ b/src/test/java/com/algorand/algosdk/integration/Stepdefs.java
@@ -1220,5 +1220,7 @@ public class Stepdefs {
 
     @When("I add a rekeyTo field with the private key algorand address")
     public void i_add_a_rekeyTo_field_with_the_private_key_algorand_address() {
+        txnBuilder.rekey(this.pk.toString());
+        txn = txnBuilder.build();
     }
 }


### PR DESCRIPTION
The step which sets the account back to the original auth address was missing, this fixes the run-order issue.