### PR TITLE
Generator refactoring.

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -46,9 +46,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.3.1</version>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>1.78</version>
         </dependency>
 
         <dependency>

--- a/generator/src/main/java/com/algorand/sdkutils/Generate.java
+++ b/generator/src/main/java/com/algorand/sdkutils/Generate.java
@@ -1,0 +1,94 @@
+package com.algorand.sdkutils;
+
+import com.algorand.sdkutils.generators.OpenApiParser;
+import com.algorand.sdkutils.generators.Utils;
+import com.algorand.sdkutils.listeners.GoGenerator;
+import com.algorand.sdkutils.listeners.Publisher;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.util.Collection;
+
+public class Generate {
+    /**
+     * This is deprecated. Use OpenApiParser:parse() instead.
+     *
+     * @param clientName     Name of the client class. i.e. IndexerClient
+     * @param specfile       Full path to the OpenAPI v2 spec file.
+     * @param modelPath      Path where generated model files will be placed.
+     * @param modelPackage   Package name to put at the top of generated model files.
+     * @param pathsPath      Path where generated path builder files will be placed.
+     * @param pathsPackage   Package name to put at the top of generated path builder files.
+     * @param commonPath     Path where the common files are, this is where the client class will be placed.
+     * @param commonPackage  Package name to put at the top of generated client class.
+     * @param tokenName      Name of the token used for this application. i.e. X-Algo-API-Token
+     * @param tokenOptional  Whether or not a no-token version of the constructor should be created.
+     * @param goDirectory    When specified, will generate go code.
+     */
+    @Deprecated
+    public static void Generate(
+            String clientName,
+            File specfile,
+            String modelPath,
+            String modelPackage,
+            String pathsPath,
+            String pathsPackage,
+            String commonPath,
+            String commonPackage,
+            String tokenName,
+            Boolean tokenOptional,
+            String goDirectory) throws Exception {
+
+        JsonNode root;
+        try (FileInputStream fis = new FileInputStream(specfile)) {
+            root = Utils.getRoot(fis);
+        }
+
+        OpenApiParser g = null;
+        Publisher publisher = new Publisher();
+
+        if (goDirectory != null && !goDirectory.isEmpty()) {
+            g = new OpenApiParser(root, publisher);
+            new GoGenerator(goDirectory, "indexer", publisher);
+        } else {
+            g = new OpenApiParser(root);
+        }
+
+        // Generate classes from the schemas
+        // These are the non-premetive types for which classes are needed
+        System.out.println("Generating " + modelPackage + " to " + modelPath);
+        g.generateAlgodIndexerObjects(root, modelPath, modelPackage);
+        g.generateEnumClasses(root, modelPath, modelPackage);
+
+        // Generate classes from the return types which have more than one return element
+        System.out.println("Generating " + modelPackage + " to " + modelPath);
+        g.generateReturnTypes(root, modelPath, modelPackage);
+
+        // Generate the algod methods
+        File imports = Files.createTempFile("imports_file", "txt").toFile();
+        File paths = Files.createTempFile("pathss_file", "txt").toFile();
+
+        System.out.println("Generating " + pathsPackage + " to " + pathsPath);
+        g.generateQueryMethods(
+                pathsPath,
+                pathsPackage,
+                modelPackage,
+                imports,
+                paths);
+
+        Collection<String> lines = Files.readAllLines(imports.toPath());
+        lines.add("import com.algorand.algosdk.crypto.Address;");
+
+        Utils.generateClientFile(
+                clientName,
+                lines,
+                paths,
+                commonPackage,
+                commonPath,
+                tokenName,
+                tokenOptional);
+        publisher.terminate();
+    }
+}

--- a/generator/src/main/java/com/algorand/sdkutils/Main.java
+++ b/generator/src/main/java/com/algorand/sdkutils/Main.java
@@ -1,226 +1,163 @@
 package com.algorand.sdkutils;
 
-import com.algorand.sdkutils.generators.Generator;
+import com.algorand.sdkutils.generators.OpenApiParser;
+import com.algorand.sdkutils.generators.ResponseGenerator;
 import com.algorand.sdkutils.generators.Utils;
-import com.algorand.sdkutils.listeners.GoGenerator;
 import com.algorand.sdkutils.listeners.Publisher;
+import com.beust.jcommander.*;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.cli.*;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.nio.file.Files;
-import java.util.Collection;
 
 public class Main {
-    public static void main (String args[]) {
-        Options o = generateOptions();
+    public static class CommonArgs {
+        @Parameter(names = {"-h", "--help"}, help = true)
+        boolean help = false;
+
+        @Parameter(names = {"-s", "--specfile"}, description = "Name of the client class. i.e. IndexerClient.")
+        File specfile;
+    }
+
+    @Parameters(commandDescription = "Generate the Java Client SDK.")
+    public static class JavaGeneratorArgs extends CommonArgs {
+        @Parameter(required = true, names = {"-n", "--client-name"}, description = "Full path to the OpenAPI v2 spec file.")
+        String clientName;
+
+        @Parameter(required = true, names = {"-m", "--model-path"}, description = "Path where generated model files will be placed.")
+        String modelPath;
+
+        @Parameter(required = true, names = {"-mp", "--model-package"}, description = "Package name to put at the top of generated model files.")
+        String modelPackage;
+
+        @Parameter(required = true, names = {"-p", "--paths-path"}, description = "Path where generated paths files will be placed.")
+        String pathsPath;
+
+        @Parameter(required = true, names = {"-pp", "--paths-package"}, description = "Package name to put at the top of generated paths files.")
+        String pathsPackage;
+
+        @Parameter(required = true, names = {"-c", "--common-path"}, description = "Path where generated client files will be placed.")
+        String commonPath;
+
+        @Parameter(required = true, names = {"-cp", "--common-package"}, description = "Package name to put at the top of generated client files.")
+        String commonPackage;
+
+        @Parameter(required = true, names = {"-t", "--token-name"}, description = "Name of the token used for this application. i.e. X-Algo-API-Token.")
+        String tokenName;
+
+        @Parameter(names = {"-tr", "--token-required"}, description = "Whether or not a no-token version of the constructor should be created.")
+        Boolean tokenRequired = false;
+    }
+
+    @Parameters(commandDescription = "Generate response test file(s).")
+    public static class ResponseGeneratorArgs extends CommonArgs {
+        @Parameter(names = {"-f", "--filter"}, description = "Only generate response files for types matching this filter regex.")
+        String filter;
+    }
+
+    private static void OptionRouter(String argv[]) throws Exception {
+        CommonArgs common = new CommonArgs();
+
+        // Java command
+        JavaGeneratorArgs java = new JavaGeneratorArgs();
+
+        // Response generator
+        ResponseGeneratorArgs responses = new ResponseGeneratorArgs();
+
+        JCommander root = JCommander.newBuilder()
+                .addObject(common)
+                .addCommand("java", java)
+                .addCommand("responses", responses)
+                .build();
+
+        root.parse(argv);
+
+        if (common.help) {
+            root.usage();
+            return;
+        }
+
+        String commandName = root.getParsedCommand();
+        JCommander command = root.getCommands().get(commandName);
+
+        switch(commandName) {
+            case "java":
+                javaGenerator(java, command);
+                return;
+            case "responses":
+                responseGenerator(responses, command);
+                return;
+
+        }
+
+    }
+
+    public static void main (String argv[]) throws Exception {
+        OptionRouter(argv);
+    }
+
+    /**
+     * Validate common arguments.
+     */
+    private static void commonValidations(CommonArgs args, JCommander command) {
+        if (args.help) {
+            command.usage();
+            System.exit(0);
+        }
+
+        if (args.specfile == null) {
+            throw new RuntimeException("Specfile must be provided with -s or --specfile");
+        }
+
+        if (!args.specfile.canRead()) {
+            throw new RuntimeException("Cannot read file: " + args.specfile.getAbsolutePath());
+        }
+    }
+
+    /**
+     * Route command to response generator.
+     */
+    private static void responseGenerator(ResponseGeneratorArgs args, JCommander command) throws Exception {
+        commonValidations(args, command);
+
+        JsonNode root;
+        try (FileInputStream fis = new FileInputStream(args.specfile)) {
+            root = Utils.getRoot(fis);
+        }
+
+        Publisher pub = new Publisher();
+        ResponseGenerator generator = new ResponseGenerator(pub);
+        OpenApiParser parser = new OpenApiParser(root, pub);
+        parser.parse();
+    }
+
+    /**
+     * Route command to java generator.
+     */
+    private static void javaGenerator(JavaGeneratorArgs args, JCommander command) {
+        commonValidations(args, command);
 
         try {
-            CommandLineParser parser = new DefaultParser();
-            CommandLine line = parser.parse(o, args);
-
-            if (line.hasOption("help")) {
-                HelpFormatter formatter = new HelpFormatter();
-                formatter.printHelp("generator", o);
-                System.exit(0);
-            }
-
-            Main.Generate(
-                    line.getOptionValue("n"),
-                    new File(line.getOptionValue("s")),
-                    line.getOptionValue("m"),
-                    line.getOptionValue("mp"),
-                    line.getOptionValue("p"),
-                    line.getOptionValue("pp"),
-                    line.getOptionValue("c"),
-                    line.getOptionValue("cp"),
-                    line.getOptionValue("t"),
-                    !line.hasOption("tr"),
+            Generate.Generate(
+                    args.clientName,
+                    args.specfile,
+                    args.modelPath,
+                    args.modelPackage,
+                    args.pathsPath,
+                    args.pathsPackage,
+                    args.commonPath,
+                    args.commonPackage,
+                    args.tokenName,
+                    args.tokenRequired,
                     null);
-        } catch (ParseException e) {
-            System.out.println("Problem processing arguments: " + e.getMessage());
-            System.out.println("\n\n");
-            e.printStackTrace();
-            System.out.println("\n\n");
-
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp("generator", o);
-            System.exit(0);
         } catch (Exception e) {
             System.out.println("Problem generating code:" + e.getMessage());
             System.out.println("\n\n");
             e.printStackTrace();
             System.out.println("\n\n");
 
-            HelpFormatter formatter = new HelpFormatter();
-            formatter.printHelp("generator", o);
+            command.usage();
             System.exit(0);
         }
-    }
-
-    /**
-     * @param clientName     Name of the client class. i.e. IndexerClient
-     * @param specfile       Full path to the OpenAPI v2 spec file.
-     * @param modelPath      Path where generated model files will be placed.
-     * @param modelPackage   Package name to put at the top of generated model files.
-     * @param pathsPath      Path where generated path builder files will be placed.
-     * @param pathsPackage   Package name to put at the top of generated path builder files.
-     * @param commonPath     Path where the common files are, this is where the client class will be placed.
-     * @param commonPackage  Package name to put at the top of generated client class.
-     * @param tokenName      Name of the token used for this application. i.e. X-Algo-API-Token
-     * @param tokenOptional  Whether or not a no-token version of the constructor should be created.
-     * @param goDirectory    When specified, will generate go code.
-     */
-    public static void Generate(
-            String clientName,
-            File specfile,
-            String modelPath,
-            String modelPackage,
-            String pathsPath,
-            String pathsPackage,
-            String commonPath,
-            String commonPackage,
-            String tokenName,
-            Boolean tokenOptional,
-            String goDirectory) throws Exception {
-
-        JsonNode root;
-        try (FileInputStream fis = new FileInputStream(specfile)) {
-            root = Utils.getRoot(fis);
-        }
-
-        Generator g = null;
-        Publisher publisher = new Publisher();
-
-        if (goDirectory != null && !goDirectory.isEmpty()) {
-            g = new Generator(root, publisher);
-            new GoGenerator(goDirectory, "indexer", publisher); 
-        } else {
-            g = new Generator(root);
-        }
-
-        // Generate classes from the schemas
-        // These are the non-premetive types for which classes are needed
-        System.out.println("Generating " + modelPackage + " to " + modelPath);
-        g.generateAlgodIndexerObjects(root, modelPath, modelPackage);
-        g.generateEnumClasses(root, modelPath, modelPackage);
-
-        // Generate classes from the return types which have more than one return element
-        System.out.println("Generating " + modelPackage + " to " + modelPath);
-        g.generateReturnTypes(root, modelPath, modelPackage);
-
-        // Generate the algod methods
-        File imports = Files.createTempFile("imports_file", "txt").toFile();
-        File paths = Files.createTempFile("pathss_file", "txt").toFile();
-
-        System.out.println("Generating " + pathsPackage + " to " + pathsPath);
-        g.generateQueryMethods(
-                pathsPath,
-                pathsPackage,
-                modelPackage,
-                imports,
-                paths);
-
-        Collection<String> lines = Files.readAllLines(imports.toPath());
-        lines.add("import com.algorand.algosdk.crypto.Address;");
-
-        Utils.generateClientFile(
-                clientName,
-                lines,
-                paths,
-                commonPackage,
-                commonPath,
-                tokenName,
-                tokenOptional);
-        publisher.terminate();
-    }
-
-    private static Options generateOptions() {
-        Options options = new Options();
-
-        options.addOption(Option.builder("h")
-                .longOpt("help")
-                .desc("Print help information.")
-                .build());
-
-        options.addOption(Option.builder("n")
-                .longOpt("client-name")
-                .desc("Name of the client class. i.e. IndexerClient")
-                .hasArg()
-                .argName("CLIENT NAME")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("s")
-                .longOpt("specfile")
-                .desc("Full path to the OpenAPI v2 spec file.")
-                .hasArg()
-                .argName("SPECFILE")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("m")
-                .longOpt("model-path")
-                .desc("Path where generated model files will be placed.")
-                .hasArg()
-                .argName("MODEL PATH")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("mp")
-                .longOpt("model-package")
-                .desc("Package name to put at the top of generated model files.")
-                .hasArg()
-                .argName("MODEL PACKAGE")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("p")
-                .longOpt("paths-path")
-                .desc("Path where generated path builder files will be placed.")
-                .hasArg()
-                .argName("PATH BUILDER PATH")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("pp")
-                .longOpt("paths-package")
-                .desc("Package name to put at the top of generated path builder files.")
-                .hasArg()
-                .argName("PATH BUILDER PACKAGE")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("c")
-                .longOpt("common-path")
-                .desc("Path where the common files are, this is where the client class will be placed.")
-                .hasArg()
-                .argName("COMMON PATH")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("cp")
-                .longOpt("common-package")
-                .desc("Package name to put at the top of generated client class.")
-                .hasArg()
-                .argName("COMMON PACKAGE")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("t")
-                .longOpt("token-name")
-                .desc("Name of the token used for this application. i.e. X-Algo-API-Token")
-                .hasArg()
-                .argName("TOKEN NAME")
-                .required()
-                .build());
-
-        options.addOption(Option.builder("tr")
-                .longOpt("token-required-flag")
-                .desc("Whether or not a no-token version of the constructor should be created.")
-                .build());
-
-        return options;
     }
 }

--- a/generator/src/main/java/com/algorand/sdkutils/RunAlgodV2Generator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/RunAlgodV2Generator.java
@@ -10,7 +10,7 @@ public class RunAlgodV2Generator {
         }
         File specfile = new File(specFilePath);
 
-        Main.Generate(
+        Generate.Generate(
                 "AlgodClient",
                 specfile,
                 "../src/main/java/com/algorand/algosdk/v2/client/model",

--- a/generator/src/main/java/com/algorand/sdkutils/RunIndexerGenerator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/RunIndexerGenerator.java
@@ -11,7 +11,7 @@ public class RunIndexerGenerator {
         }
         File specfile = new File(specFilePath);
 
-        Main.Generate(
+        Generate.Generate(
                 "IndexerClient",
                 specfile,
                 "../src/main/java/com/algorand/algosdk/v2/client/model",

--- a/generator/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -427,31 +427,6 @@ public class OpenApiParser {
         return null;
     }
 
-    /*
-     *  {
-     *      int field1 = rand();
-     *      int field2 = rand();
-     *      Schema schema1 = new Schema(rand(), rand());
-     *      Schema schema2 = new Schema(rand(), rand());
-     *   }
-     *
-     *   {
-     *       "field1": { "type": integer },
-     *       "field2": { "type": integer },
-     *       "schema1": { "type": $ref:Schema },
-     *       "schema2": { "type": $ref:Schema },
-     *       "program": {
-     *           "type": "object",
-     *           "properties" : {
-                     "field1": { "type": integer },
-                     "field2": { "type": integer },
-     *           }
-     *       }
-     *   }
-     *
-     *
-     */
-
     // Write the properties of the Model class.
     void writeProperties(StringBuffer buffer, Iterator<Entry<String, JsonNode>> properties, Map<String, Set<String>> imports) {
         while (properties.hasNext()) {

--- a/generator/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -400,6 +400,31 @@ public class Generator {
         return null;
     }
 
+    /*
+     *  {
+     *      int field1 = rand();
+     *      int field2 = rand();
+     *      Schema schema1 = new Schema(rand(), rand());
+     *      Schema schema2 = new Schema(rand(), rand());
+     *   }
+     *
+     *   {
+     *       "field1": { "type": integer },
+     *       "field2": { "type": integer },
+     *       "schema1": { "type": $ref:Schema },
+     *       "schema2": { "type": $ref:Schema },
+     *       "program": {
+     *           "type": "object",
+     *           "properties" : {
+                     "field1": { "type": integer },
+                     "field2": { "type": integer },
+     *           }
+     *       }
+     *   }
+     *
+     *
+     */
+
     // Write the properties of the Model class.
     void writeProperties(StringBuffer buffer, Iterator<Entry<String, JsonNode>> properties, Map<String, Set<String>> imports) {
         while (properties.hasNext()) {

--- a/generator/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -1,9 +1,7 @@
 package com.algorand.sdkutils.generators;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -20,11 +18,40 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.algorand.sdkutils.utils.*;
 
-public class Generator {
+public class OpenApiParser {
     public static final String TAB = "    ";
 
     protected JsonNode root;
     protected Publisher publisher;
+    protected final boolean legacyMode;
+
+    /**
+     * Parse the file and drive the publisher.
+     */
+    public void parse() throws Exception {
+        // TODO: Verify compatible OpenAPI version.
+
+        System.out.println("Parsing definitions.");
+        this.generateAlgodIndexerObjects(root, null, null);
+
+        // Generate classes from the return types which have more than one return element
+        System.out.println("Parsing responses.");
+        this.generateReturnTypes(root, null, null);
+
+        // Generate the algod methods
+        File imports = Files.createTempFile("imports_file", "txt").toFile();
+        File paths = Files.createTempFile("paths_file", "txt").toFile();
+
+        System.out.println("Parsing paths.");
+        this.generateQueryMethods(
+                null,
+                null,
+                null,
+                imports,
+                paths);
+
+        publisher.terminate();
+    }
 
     static BufferedWriter getFileWriter(String className, String directory) throws IOException {
         File f = new File(directory + "/" + className + ".java");
@@ -482,8 +509,6 @@ public class Generator {
 
         Iterator<Entry<String, JsonNode>> properties = getSortedProperties(propertiesNode);
         className = Tools.getCamelCase(className, true);
-        BufferedWriter bw = getFileWriter(className, directory);
-        bw.append("package " + pkg + ";\n\n");
 
         HashMap<String, Set<String>> imports = new HashMap<String, Set<String>>();
         StringBuffer body = new StringBuffer();
@@ -498,14 +523,19 @@ public class Generator {
         addImport(imports, "com.algorand.algosdk.v2.client.common.PathResponse");
         addImport(imports, "com.fasterxml.jackson.annotation.JsonProperty");
 
-        bw.append(getImports(imports));
-        if (desc != null) {
-            bw.append(Tools.formatComment(desc, "", true));
+        if (legacyMode) {
+            BufferedWriter bw = getFileWriter(className, directory);
+            bw.append("package " + pkg + ";\n\n");
+
+            bw.append(getImports(imports));
+            if (desc != null) {
+                bw.append(Tools.formatComment(desc, "", true));
+            }
+            bw.append("public class " + className + " extends PathResponse {\n\n");
+            bw.append(body);
+            bw.append("}\n");
+            bw.close();
         }
-        bw.append("public class " + className + " extends PathResponse {\n\n");
-        bw.append(body);
-        bw.append("}\n");
-        bw.close();
     }
 
     // getPathInserts converts the path string into individual tokens which correspond
@@ -582,7 +612,7 @@ public class Generator {
 
         StringBuffer generatedPathsEntryBody = new StringBuffer();
 
-        requestMethod.append(Generator.getQueryResponseMethod(returnType));
+        requestMethod.append(OpenApiParser.getQueryResponseMethod(returnType));
         requestMethod.append("    protected QueryData getRequestString() {\n");
         boolean pAdded = false;
         boolean addFormatMsgpack = false;
@@ -759,9 +789,9 @@ public class Generator {
             returnType = spec.get("responses").get("200").get("$ref").asText();
             JsonNode returnTypeNode = this.getFromRef(returnType);
             if (returnTypeNode.get("schema").get("$ref") != null) {
-                returnType = Generator.getTypeNameFromRef(returnTypeNode.get("schema").get("$ref").asText());
+                returnType = OpenApiParser.getTypeNameFromRef(returnTypeNode.get("schema").get("$ref").asText());
             } else {
-                returnType = Generator.getTypeNameFromRef(returnType);
+                returnType = OpenApiParser.getTypeNameFromRef(returnType);
                 returnType = Tools.getCamelCase(returnType, true);
             }
         }
@@ -773,9 +803,6 @@ public class Generator {
             properties = getSortedParameters(paramNode);
         }
 
-        BufferedWriter bw = getFileWriter(className, directory);
-        bw.append("package " + pkg + ";\n\n");
-
         Map<String, Set<String>> imports = new HashMap<String, Set<String>>();
         addImport(imports, "com.algorand.algosdk.v2.client.common.Client");
         addImport(imports, "com.algorand.algosdk.v2.client.common.HttpMethod");
@@ -786,69 +813,75 @@ public class Generator {
             addImport(imports, modelPkg + "." + returnType);
         }
 
-        StringBuffer sb = new StringBuffer();
-        sb.append("\n");
-        sb.append(Tools.formatComment(discAndPath, "", true));
         generatedPathsEntry.append(Tools.formatComment(discAndPath, TAB, true));
         
         generatedPathsEntry.append("    public " + className + " " + methodName + "(");
         String [] strarray = {className, returnType, path, desc};
         this.publisher.publish(Events.NEW_QUERY, strarray);
-   
-        sb.append("public class " + className + " extends Query {\n\n");
-        sb.append(
-                processQueryParams(
-                        generatedPathsEntry,
-                        properties,
-                        className,
-                        path,
-                        returnType,
-                        httpMethod,
-                        imports));
-        sb.append("\n}");
-        bw.append(getImports(imports));
-        bw.append(sb);
-        bw.close();
+
+        if (legacyMode) {
+            StringBuffer sb = new StringBuffer();
+            sb.append("\n");
+            sb.append(Tools.formatComment(discAndPath, "", true));
+            sb.append("public class " + className + " extends Query {\n\n");
+            sb.append(
+                    processQueryParams(
+                            generatedPathsEntry,
+                            properties,
+                            className,
+                            path,
+                            returnType,
+                            httpMethod,
+                            imports));
+            sb.append("\n}");
+
+            BufferedWriter bw = getFileWriter(className, directory);
+            bw.append("package " + pkg + ";\n\n");
+            bw.append(getImports(imports));
+            bw.append(sb);
+            bw.close();
+        }
         
         publisher.publish(Events.END_QUERY);
     }
 
     // Generate all the enum classes in the spec file. 
     public void generateEnumClasses (JsonNode root, String rootPath, String pkg) throws IOException {
+        if (legacyMode) {
+            BufferedWriter bw = getFileWriter("Enums", rootPath);
+            bw.append("package " + pkg + ";\n\n");
+            bw.append("import com.fasterxml.jackson.annotation.JsonProperty;\n\n");
+            bw.append("public class Enums {\n\n");
+            JsonNode parameters = root.get("parameters");
+            Iterator<Entry<String, JsonNode>> classes = parameters.fields();
+            while (classes.hasNext()) {
+                Entry<String, JsonNode> cls = classes.next();
+                if (cls.getValue().get("enum") != null) {
 
-        BufferedWriter bw = getFileWriter("Enums", rootPath);
-        bw.append("package " + pkg + ";\n\n");
-        bw.append("import com.fasterxml.jackson.annotation.JsonProperty;\n\n");
-        bw.append("public class Enums {\n\n");
-        JsonNode parameters = root.get("parameters");
-        Iterator<Entry<String, JsonNode>> classes = parameters.fields();
-        while (classes.hasNext()) {
-            Entry<String, JsonNode> cls = classes.next();
-            if (cls.getValue().get("enum") != null) {
+                    // Do not expose format property
+                    if (cls.getKey().equals("format")) {
+                        continue;
+                    }
 
-                // Do not expose format property
-                if (cls.getKey().equals("format")) {
-                    continue;
+                    if (cls.getValue().get("description") != null) {
+                        String comment = null;
+                        comment = cls.getValue().get("description").asText();
+                        bw.append(Tools.formatComment(comment, "", true));
+                    }
+                    TypeDef enumType = getEnum(cls.getValue(), cls.getKey(), "");
+                    bw.append(enumType.def);
+                    bw.append("\n");
                 }
-
-                if (cls.getValue().get("description") != null) {
-                    String comment = null;
-                    comment = cls.getValue().get("description").asText();
-                    bw.append(Tools.formatComment(comment, "", true));
-                }
-                TypeDef enumType = getEnum(cls.getValue(), cls.getKey(), "");
-                bw.append(enumType.def);
-                bw.append("\n");
             }
+            bw.append("}\n");
+            bw.close();
         }
-        bw.append("}\n");
-        bw.close();
     }
 
     // Generate all the Indexer or algod model classes 
     public void generateAlgodIndexerObjects (JsonNode root, String rootPath, String pkg) throws IOException {
-        JsonNode schemas = root.get("components") != null ? 
-                root.get("components").get("schemas") : 
+        JsonNode schemas = root.get("components") != null ?
+                root.get("components").get("schemas") :
                     root.get("definitions");
                 Iterator<Entry<String, JsonNode>> classes = schemas.fields();
                 while (classes.hasNext()) {
@@ -910,21 +943,25 @@ public class Generator {
                 }
                 writeQueryClass(gpBody, path.getValue(), path.getKey(), rootPath, pkg, modelPkg);
 
-                // Fill GeneratedPaths class
-                String className = Tools.getCamelCase(path.getValue().findPath("operationId").asText(), true);
-                gpImports.append("import " + pkg + "." + className + ";\n");
+                if (legacyMode) {
+                    // Fill GeneratedPaths class
+                    String className = Tools.getCamelCase(path.getValue().findPath("operationId").asText(), true);
+                    gpImports.append("import " + pkg + "." + className + ";\n");
+                }
             }
             gpMethods.append(gpBody);
         }
     }
 
 
-    public Generator (JsonNode root) {
+    public OpenApiParser(JsonNode root) {
+        this.legacyMode = true;
         this.root = root;
         this.publisher = new Publisher();
     }
 
-    public Generator (JsonNode root, Publisher publisher) {
+    public OpenApiParser(JsonNode root, Publisher publisher) {
+        this.legacyMode = false;
         this.root = root;
         this.publisher = publisher;
     }

--- a/generator/src/main/java/com/algorand/sdkutils/generators/QueryMapperGenerator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/QueryMapperGenerator.java
@@ -9,7 +9,7 @@ import com.algorand.sdkutils.utils.Tools;
 import com.algorand.sdkutils.utils.TypeDef;
 import com.fasterxml.jackson.databind.JsonNode;
 
-public class QueryMapperGenerator extends Generator {
+public class QueryMapperGenerator extends OpenApiParser {
 
     JsonNode indexer;
     JsonNode algod;
@@ -130,7 +130,7 @@ public class QueryMapperGenerator extends Generator {
             Iterator<JsonNode> enumVals = parameter.getValue().get("enum") == null ? null : 
                 parameter.getValue().get("enum").elements();
             String javaEnumName = Tools.getCamelCase(parameter.getKey(), true);
-            String format = Generator.getTypeFormat(typeNode, parameter.getKey());
+            String format = OpenApiParser.getTypeFormat(typeNode, parameter.getKey());
 
             if (inPath(parameter.getValue())) {
                 if (argCounter > 0) {

--- a/generator/src/main/java/com/algorand/sdkutils/generators/ResponseGenerator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/ResponseGenerator.java
@@ -1,0 +1,42 @@
+package com.algorand.sdkutils.generators;
+
+import com.algorand.sdkutils.listeners.Publisher;
+import com.algorand.sdkutils.listeners.Subscriber;
+import com.algorand.sdkutils.utils.StructDef;
+import com.algorand.sdkutils.utils.TypeDef;
+import com.beust.jcommander.Strings;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class ResponseGenerator extends Subscriber {
+
+    public ResponseGenerator(Publisher publisher) {
+        publisher.subscribeAll(this);
+    }
+
+    @Override
+    public void terminate() {
+        System.out.println("TERMINATE");
+    }
+
+    @Override
+    public void onEvent(Publisher.Events event) {
+        System.out.println("(event) - " + event);
+    }
+
+    @Override
+    public void onEvent(Publisher.Events event, String[] notes) {
+        System.out.println("(event, []notes) - " + String.join(",", notes));
+    }
+
+    @Override
+    public void onEvent(Publisher.Events event, TypeDef type) {
+        System.out.println("(event, TypeDef) - " + type.toString());
+    }
+
+    @Override
+    public void onEvent(Publisher.Events event, StructDef sDef) {
+        System.out.println("(event, TypeDef) - " + sDef.toString());
+    }
+}

--- a/generator/src/main/java/com/algorand/sdkutils/generators/TemplateGenerator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/TemplateGenerator.java
@@ -10,7 +10,7 @@ import java.util.Map.Entry;
 import com.algorand.sdkutils.utils.Tools;
 import com.fasterxml.jackson.databind.JsonNode;
 
-public class TemplateGenerator extends Generator{
+public class TemplateGenerator extends OpenApiParser {
 
     public TemplateGenerator(JsonNode root) {
         super(root);

--- a/generator/src/main/java/com/algorand/sdkutils/generators/TestGenerator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/TestGenerator.java
@@ -13,7 +13,7 @@ import com.algorand.sdkutils.generated.QueryMapper;
  */
 import com.fasterxml.jackson.databind.JsonNode;
 
-public class TestGenerator extends Generator {
+public class TestGenerator extends OpenApiParser {
     static String callExternalCurl(String request) {
         StringBuffer bw = new StringBuffer();
         ProcessBuilder processBuilder = new ProcessBuilder();

--- a/generator/src/main/java/com/algorand/sdkutils/listeners/GoGenerator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/listeners/GoGenerator.java
@@ -75,14 +75,7 @@ public class GoGenerator extends Subscriber {
 
 
     public GoGenerator(String rootFolder, String packageName, Publisher publisher) throws IOException {
-        publisher.subscribe(Events.NEW_MODEL, this);
-        publisher.subscribe(Events.NEW_PROPERTY, this);
-        publisher.subscribe(Events.NEW_RETURN_TYPE, this);
-        publisher.subscribe(Events.NEW_QUERY, this);
-        publisher.subscribe(Events.QUERY_PARAMETER, this);
-        publisher.subscribe(Events.PATH_PARAMETER, this);
-        publisher.subscribe(Events.BODY_CONTENT, this);
-        publisher.subscribe(Events.END_QUERY, this);
+        publisher.subscribeAll(this);
 
         modelWriter = null;
         clientFunctions = new TreeMap<String, String>();

--- a/generator/src/main/java/com/algorand/sdkutils/listeners/Publisher.java
+++ b/generator/src/main/java/com/algorand/sdkutils/listeners/Publisher.java
@@ -37,7 +37,18 @@ public class Publisher {
             subscriber.terminate();
         }
     }
-    
+
+    public void subscribeAll(Subscriber sub) {
+        subscribe(Events.NEW_MODEL, sub);
+        subscribe(Events.NEW_PROPERTY, sub);
+        subscribe(Events.NEW_RETURN_TYPE, sub);
+        subscribe(Events.NEW_QUERY, sub);
+        subscribe(Events.QUERY_PARAMETER, sub);
+        subscribe(Events.PATH_PARAMETER, sub);
+        subscribe(Events.BODY_CONTENT, sub);
+        subscribe(Events.END_QUERY, sub);
+    }
+
     public void subscribe(Events event, Subscriber subscriber) {
         if (subscribers.get(event) == null) {
             subscribers.put(event, new ArrayList<Subscriber>());

--- a/generator/src/main/java/com/algorand/sdkutils/utils/StructDef.java
+++ b/generator/src/main/java/com/algorand/sdkutils/utils/StructDef.java
@@ -9,4 +9,9 @@ public class StructDef {
         this.name = name;
         this.doc = doc;
     }
+
+    @Override
+    public String toString() {
+        return "name: '" + name + "', " + "doc: '" + doc + "'";
+    }
 }

--- a/generator/src/main/java/com/algorand/sdkutils/utils/TypeDef.java
+++ b/generator/src/main/java/com/algorand/sdkutils/utils/TypeDef.java
@@ -56,7 +56,14 @@ public class TypeDef {
 
     @Override
     public String toString() {
-        throw new RuntimeException("Should not get the string value of the object directly!");
+        return
+                "javaTypeName: '" + javaTypeName + "', " +
+                "rawTypeName: '" + rawTypeName + "', " +
+                "def: '" + def + "', " +
+                "propertyName: '" + propertyName + "', " +
+                "goPropertyName: '" + goPropertyName + "', " +
+                "doc: '" + doc + "', " +
+                "required: '" + required + "'";
     }
 
     public String javaTypeName;

--- a/run_generator.sh
+++ b/run_generator.sh
@@ -67,6 +67,7 @@ fi
 mvn package
 
 java -jar target/generator-*-jar-with-dependencies.jar \
+       java \
        -c  "../src/main/java/com/algorand/algosdk/v2/client/common" \
        -cp "com.algorand.algosdk.v2.client.common" \
        -m  "../src/main/java/com/algorand/algosdk/v2/client/model" \
@@ -78,6 +79,7 @@ java -jar target/generator-*-jar-with-dependencies.jar \
        -s  "$INDEXER_SPEC"
 
 java -jar target/generator-*-jar-with-dependencies.jar \
+       java \
        -c  "../src/main/java/com/algorand/algosdk/v2/client/common" \
        -cp "com.algorand.algosdk.v2.client.common" \
        -m  "../src/main/java/com/algorand/algosdk/v2/client/model" \


### PR DESCRIPTION
* `Generator` -> `OpenApiParser`
* `legacyMode` flag in `OpenApiParser` so that the parser can run without supplying java configurations.
* `parse()` function in `OpenApiParser` to more intuitively run the operations done by the static `Generate` method (and only the required operations).
* Improved CLI parsing to allow multiple subcommands.
* Stubbed in `responses` subcommand.