### PR TITLE
Improve go generator

### DIFF
--- a/generator/src/main/java/com/algorand/sdkutils/generators/Generator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/Generator.java
@@ -765,11 +765,11 @@ public class Generator {
         sb.append("\n");
         sb.append(Tools.formatComment(discAndPath, "", true));
         generatedPathsEntry.append(Tools.formatComment(discAndPath, TAB, true));
-        
+
         generatedPathsEntry.append("    public " + className + " " + methodName + "(");
-        String [] strarray = {className, returnType, path, desc};
+        String [] strarray = {className, returnType, path, desc, httpMethod};
         this.publisher.publish(Events.NEW_QUERY, strarray);
-   
+
         sb.append("public class " + className + " extends Query {\n\n");
         sb.append(
                 processQueryParams(
@@ -784,7 +784,7 @@ public class Generator {
         bw.append(getImports(imports));
         bw.append(sb);
         bw.close();
-        
+
         publisher.publish(Events.END_QUERY);
     }
 

--- a/generator/src/main/java/com/algorand/sdkutils/listeners/GoGenerator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/listeners/GoGenerator.java
@@ -61,6 +61,8 @@ public class GoGenerator extends Subscriber {
     private String pathDesc;
     // path encoded with place-holders from the spec
     private String path;
+    // request method
+    private String httpMethod;
 
     // client functions
 
@@ -129,15 +131,17 @@ public class GoGenerator extends Subscriber {
     // Constructs the Do function, which returns the response object 
     private StringBuffer getDoFunction() {
         StringBuffer sb = new StringBuffer();
+        String desc = Tools.formatCommentGo("Do performs HTTP request", "", "");
+        sb.append(desc);
         sb.append("func (s *" + currentQueryName + ") Do(ctx context.Context,\n" + 
                 TAB + "headers ...*common.Header) (response models." + currentQueryReturn + ", err error) {\n");
 
-        sb.append(TAB + "err = s.c.get(ctx, &response,\n");
+        sb.append(TAB + "err = s.c." + this.httpMethod + "(ctx, &response,\n");
         sb.append(TAB + TAB + processPath());
         if (queryFunctions.length() == 0) {
             sb.append(", nil, headers)\n");
         } else {
-            sb.append(", s.p, headers)\n");   
+            sb.append(", s.p, headers)\n");
         }
 
         sb.append(TAB + "return\n}\n");
@@ -151,7 +155,7 @@ public class GoGenerator extends Subscriber {
             endQuery();
             break;
         default:
-            throw new RuntimeException("Unemplemented event! " + event);
+            throw new RuntimeException("Unimplemented event! " + event);
         }
     }
 
@@ -159,10 +163,10 @@ public class GoGenerator extends Subscriber {
     public void onEvent(Events event, String [] notes) {
         switch(event) {
         case NEW_QUERY:
-            newQuery(notes[0], notes[1], notes[2], notes[3]);
+            newQuery(notes[0], notes[1], notes[2], notes[3], notes[4]);
             break;
         default:
-            throw new RuntimeException("Unemplemented event for note! " + event);
+            throw new RuntimeException("Unimplemented event for note! " + event);
         }
     }
 
@@ -181,7 +185,7 @@ public class GoGenerator extends Subscriber {
         case BODY_CONTENT:
             break;
         default:
-            throw new RuntimeException("Unemplemented event for TypeDef! " + event);
+            throw new RuntimeException("Unimplemented event for TypeDef! " + event);
         }
     }
 
@@ -250,7 +254,7 @@ public class GoGenerator extends Subscriber {
         if (pathParameters.size() > 0) {
             pathSB.append(")");
         }
-        
+
         return pathSB;
     }
 
@@ -260,10 +264,12 @@ public class GoGenerator extends Subscriber {
             String className,
             String returnTypeName,
             String path,
-            String desc) {
+            String desc,
+            String httpMethod) {
 
-        pathDesc = path + "\n" + desc;
+        this.pathDesc = path + "\n" + desc;
         this.path = path;
+        this.httpMethod = httpMethod;
         currentQueryName = Tools.getCamelCase(className, true);
         currentQueryReturn = Tools.getCamelCase(returnTypeName, true);
 
@@ -294,7 +300,7 @@ public class GoGenerator extends Subscriber {
 
         // client functions
         if (pathParameters.size() > 1) {
-            clientFunction.append(", ");   
+            clientFunction.append(", ");
         }
         clientFunction.append(propName + " " + gotype);
     }
@@ -306,7 +312,7 @@ public class GoGenerator extends Subscriber {
         String propName = type.goPropertyName.isEmpty() ? type.propertyName : type.goPropertyName;
         String funcName = Tools.getCamelCase(propName, true);
         String paramName = Tools.getCamelCase(propName, false);
-        String desc = Tools.formatComment(type.doc, "", true);
+        String desc = Tools.formatCommentGo(type.doc, funcName, "");
         TypeConverter typeConv = goType(type.rawTypeName, type.isOfType("array"), 
                 true, propName);
 
@@ -347,7 +353,7 @@ public class GoGenerator extends Subscriber {
         append(queryWriter, getImports());
         append(queryWriter, ")\n\n");
 
-        append(queryWriter, Tools.formatComment(pathDesc, "", true));
+        append(queryWriter, Tools.formatCommentGo(pathDesc, currentQueryName, ""));
         append(queryWriter, "type " + currentQueryName + " struct {\n");
 
         int formattingWidth = 1;
@@ -377,7 +383,7 @@ public class GoGenerator extends Subscriber {
         clientFunction.append("}\n}\n\n");
 
         clientFunctions.put(currentQueryName, 
-                Tools.formatComment(pathDesc, "", true) + clientFunction.toString());
+                Tools.formatCommentGo(pathDesc, "", "") + clientFunction.toString());
 
         append(queryWriter, queryFunctions.toString());
         append(queryWriter, getDoFunction());
@@ -652,9 +658,10 @@ final class ModelWriter {
     public void newProperty(TypeDef type, GoGenerator.Annotation annType) {
         modelPropertyAdded = true;
         String propName = type.goPropertyName.isEmpty() ? type.propertyName : type.goPropertyName;
+        propName = Tools.getCamelCase(propName, true);
         GoGenerator.append(currentModelBuffer, "\n");
-        GoGenerator.append(currentModelBuffer, Tools.formatComment(type.doc, GoGenerator.TAB, true));
-        GoGenerator.append(currentModelBuffer, GoGenerator.TAB + Tools.getCamelCase(propName, true) + " ");
+        GoGenerator.append(currentModelBuffer, Tools.formatCommentGo(type.doc, propName, GoGenerator.TAB));
+        GoGenerator.append(currentModelBuffer, GoGenerator.TAB + propName + " ");
         GoGenerator.append(currentModelBuffer, gogen.goType(type.rawTypeName, type.isOfType("array")) + " ");
         GoGenerator.append(currentModelBuffer, GoGenerator.goAnnotation(type.propertyName, annType, type.required));
         if (type.propertyName.charAt(0) == 'A') {
@@ -682,7 +689,7 @@ final class ModelWriter {
         }
         currentModelBuffer = new StringBuffer();
         if (sDef.doc != null) {
-            GoGenerator.append(currentModelBuffer, Tools.formatComment(sDef.doc, "", true));
+            GoGenerator.append(currentModelBuffer, Tools.formatCommentGo(sDef.doc, sDef.name, ""));
         }
         GoGenerator.append(currentModelBuffer, "type " + sDef.name + " struct {");
         pendingOpenStruct = true;

--- a/generator/src/main/java/com/algorand/sdkutils/utils/Tools.java
+++ b/generator/src/main/java/com/algorand/sdkutils/utils/Tools.java
@@ -1,27 +1,63 @@
 package com.algorand.sdkutils.utils;
 
+import java.lang.Character;
 import java.util.StringTokenizer;
 
 public class Tools {
 
-    // formatComment formats the comment by breaking lines, and incorporating 
-    // embedded formatting inside the comment. 
+    // formatComment formats the comment by breaking lines, and incorporating
+    // embedded formatting inside the comment.
     // If the comment is embedded inside another comment, full == false
     public static String formatComment(String comment, String tab, boolean full) {
         if (comment == null || comment.isEmpty()) {
             return "";
         }
         StringBuffer sb = new StringBuffer();
-
-        comment = comment.replace("\\[", "(");
-        comment = comment.replace("\\]", ")");
-        comment = comment.replace("\n", " __NEWLINE__ ");
         if (full) {
             sb.append(tab+"/**");
             sb.append("\n"+tab+" *");
         } else {
             sb.append(tab+" *");
         }
+
+        formatCommentImpl(sb, comment, " *", tab);
+
+        if (full) {
+            sb.append("\n"+tab+" */\n");
+        }
+        return sb.toString();
+    }
+
+    public static String formatCommentGo(String comment, String name, String tab) {
+        if (comment == null || comment.isEmpty()) {
+            return "";
+        }
+        String commentPossibleModified = comment;
+        if (name.length() > 0 && !comment.startsWith(name)) {
+            char firstChar = comment.charAt(0);
+            if (Character.isUpperCase(firstChar)) {
+                firstChar = Character.toLowerCase(firstChar);
+            }
+            commentPossibleModified = name + " " + firstChar + comment.substring(1);
+        }
+        int endIndex = commentPossibleModified.length();
+        if (commentPossibleModified.endsWith("\n") && endIndex > 2) {
+            commentPossibleModified = commentPossibleModified.substring(0, endIndex-1);
+        }
+        StringBuffer sb = new StringBuffer();
+        sb.append(tab+"//");
+        formatCommentImpl(sb, commentPossibleModified, "//", tab);
+        sb.append("\n");
+        return sb.toString();
+    }
+
+    private static void formatCommentImpl(
+        StringBuffer sb, String comment,
+        String comStr, String tab
+    ) {
+        comment = comment.replace("\\[", "(");
+        comment = comment.replace("\\]", ")");
+        comment = comment.replace("\n", " __NEWLINE__ ");
 
         StringTokenizer st = new StringTokenizer(comment);
         int line = 0;
@@ -32,24 +68,23 @@ public class Tools {
                     continue;
                 } else {
                     line = 0;
-                    sb.append("\n"+tab+" *");
+                    sb.append("\n"+tab+comStr);
                     continue;
                 }
             }
             if (line + token.length() > 80) {
                 line = 0;
-                sb.append("\n"+tab+" *");
+                sb.append("\n"+tab+comStr);
             }
-            token = token.replace('*', ' ');
+            if (comStr.indexOf("*") != -1) {
+                token = token.replace('*', ' ');
+            }
             sb.append(" ");
 
             sb.append(token);
             line += token.length() + 1;
         }
-        if (full) {
-            sb.append("\n"+tab+" */\n");
-        }
-        return sb.toString();
+        return;
     }
 
     public static String getCamelCase(String name, boolean firstCap) {


### PR DESCRIPTION
* Make go-lint compatible comments, Java should be affected.
* Pass request method to Do generator

Examples of new style comments in go:
```
// Account information at a given round.
// Definition:
// data/basics/userBalance.go : AccountData
type Account struct {
```

```
// Metrics /metrics
type Metrics struct {
	c *Client
}

// Do performs HTTP request
func (s *Metrics) Do(ctx context.Context,
```