### PR TITLE
correct array of byte arrays used by application-args.

### DIFF
--- a/generator/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/generator/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -135,6 +135,7 @@ public class OpenApiParser {
             case "byte":
             case "base64":
             case "digest":
+            case "TEALProgram":
                 if (type.contentEquals("array")) {
                     type = prop.get("items").get("type").asText();
                     if (forModel == false) {

--- a/generator/src/main/java/com/algorand/sdkutils/listeners/GoGenerator.java
+++ b/generator/src/main/java/com/algorand/sdkutils/listeners/GoGenerator.java
@@ -575,6 +575,7 @@ public class GoGenerator implements Subscriber {
             break;
 
         case "binary":
+        case "byte":
             goType = "[]byte";
             if (asType) {
                 addImport("A", "encoding/base64");

--- a/src/main/java/com/algorand/algosdk/v2/client/model/ApplicationParams.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/model/ApplicationParams.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.algorand.algosdk.crypto.Address;
+import com.algorand.algosdk.util.Encoder;
 import com.algorand.algosdk.v2.client.common.PathResponse;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -18,13 +19,27 @@ public class ApplicationParams extends PathResponse {
      * (approv) approval program.
      */
     @JsonProperty("approval-program")
-    public String approvalProgram;
+    public void approvalProgram(String base64Encoded) {
+        this.approvalProgram = Encoder.decodeFromBase64(base64Encoded);
+    }
+    @JsonProperty("approval-program")
+    public String approvalProgram() {
+        return Encoder.encodeToBase64(this.approvalProgram);
+    }
+    public byte[] approvalProgram;
 
     /**
      * (clearp) approval program.
      */
     @JsonProperty("clear-state-program")
-    public String clearStateProgram;
+    public void clearStateProgram(String base64Encoded) {
+        this.clearStateProgram = Encoder.decodeFromBase64(base64Encoded);
+    }
+    @JsonProperty("clear-state-program")
+    public String clearStateProgram() {
+        return Encoder.encodeToBase64(this.clearStateProgram);
+    }
+    public byte[] clearStateProgram;
 
     /**
      * The address that created this application. This is the address where the

--- a/src/main/java/com/algorand/algosdk/v2/client/model/BlockResponse.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/model/BlockResponse.java
@@ -1,7 +1,39 @@
 package com.algorand.algosdk.v2.client.model;
 
+import java.util.HashMap;
 import java.util.Objects;
 
 import com.algorand.algosdk.v2.client.common.PathResponse;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Encoded block object.
+ */
+public class BlockResponse extends PathResponse {
+
+    /**
+     * Block header data.
+     */
+    @JsonProperty("block")
+    public HashMap<String,Object> block;
+
+    /**
+     * Optional certificate object. This is only included when the format is set to
+     * message pack.
+     */
+    @JsonProperty("cert")
+    public HashMap<String,Object> cert;
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) return true;
+        if (o == null) return false;
+
+        BlockResponse other = (BlockResponse) o;
+        if (!Objects.deepEquals(this.block, other.block)) return false;
+        if (!Objects.deepEquals(this.cert, other.cert)) return false;
+
+        return true;
+    }
+}

--- a/src/main/java/com/algorand/algosdk/v2/client/model/BlockResponse.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/model/BlockResponse.java
@@ -1,39 +1,7 @@
 package com.algorand.algosdk.v2.client.model;
 
-import java.util.HashMap;
 import java.util.Objects;
 
 import com.algorand.algosdk.v2.client.common.PathResponse;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * Encoded block object.
- */
-public class BlockResponse extends PathResponse {
-
-    /**
-     * Block header data.
-     */
-    @JsonProperty("block")
-    public HashMap<String,Object> block;
-
-    /**
-     * Optional certificate object. This is only included when the format is set to
-     * message pack.
-     */
-    @JsonProperty("cert")
-    public HashMap<String,Object> cert;
-
-    @Override
-    public boolean equals(Object o) {
-
-        if (this == o) return true;
-        if (o == null) return false;
-
-        BlockResponse other = (BlockResponse) o;
-        if (!Objects.deepEquals(this.block, other.block)) return false;
-        if (!Objects.deepEquals(this.cert, other.cert)) return false;
-
-        return true;
-    }
-}

--- a/src/main/java/com/algorand/algosdk/v2/client/model/TransactionApplication.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/model/TransactionApplication.java
@@ -72,7 +72,14 @@ public class TransactionApplication extends PathResponse {
      * reject the transaction.
      */
     @JsonProperty("approval-program")
-    public String approvalProgram;
+    public void approvalProgram(String base64Encoded) {
+        this.approvalProgram = Encoder.decodeFromBase64(base64Encoded);
+    }
+    @JsonProperty("approval-program")
+    public String approvalProgram() {
+        return Encoder.encodeToBase64(this.approvalProgram);
+    }
+    public byte[] approvalProgram;
 
     /**
      * (apsu) Logic executed for application transactions with on-completion set to
@@ -81,7 +88,14 @@ public class TransactionApplication extends PathResponse {
      * transaction.
      */
     @JsonProperty("clear-state-program")
-    public String clearStateProgram;
+    public void clearStateProgram(String base64Encoded) {
+        this.clearStateProgram = Encoder.decodeFromBase64(base64Encoded);
+    }
+    @JsonProperty("clear-state-program")
+    public String clearStateProgram() {
+        return Encoder.encodeToBase64(this.clearStateProgram);
+    }
+    public byte[] clearStateProgram;
 
     /**
      * (apfa) Lists the applications in addition to the application-id whose global


### PR DESCRIPTION
1. Correct array of byte array type. It is used by application-args.

2. Fix for conflicting alias type classes 
No file should be generated when the type is an alias.
There are some alias types in one spec file, which
are in contradiction with real types in the other spec file.
We don't want the alias type file to corrupt the real type object.