### PR TITLE
New constructors for v2 and Indexer that also accepts tokenKey

### DIFF
--- a/src/main/java/com/algorand/algosdk/v2/client/common/AlgodClient.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/common/AlgodClient.java
@@ -31,6 +31,18 @@ public class AlgodClient extends Client {
     public AlgodClient(String host, int port, String token) {
         super(host, port, token, "X-Algo-API-Token");
     }
+
+    /**
+     * Construct an AlgodClient with custom token key for communicating with the REST API.
+     * @param host using a URI format. If the scheme is not supplied the client will use HTTP.
+     * @param port REST server port.
+     * @param token authentication token.
+     * @param tokenKey authentication token key.
+     */
+    public AlgodClient(String host, int port, String token, String tokenKey) {
+        super(host, port, token, tokenKey);
+    }
+
     /**
      * Returns OK if healthy.
      * /health

--- a/src/main/java/com/algorand/algosdk/v2/client/common/IndexerClient.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/common/IndexerClient.java
@@ -36,6 +36,17 @@ public class IndexerClient extends Client {
     }
 
     /**
+     * Construct an IndexerClient for communicating with the REST API.
+     * @param host using a URI format. If the scheme is not supplied the client will use HTTP.
+     * @param port REST server port.
+     * @param token authentication token.
+     * @param tokenKey authentication token key.
+     */
+    public IndexerClient(String host, int port, String token, String tokenKey) {
+        super(host, port, token, tokenKey);
+    }
+
+    /**
      * Returns 200 if healthy.
      * /health
      */


### PR DESCRIPTION
Added new constructors to algodv2 and indexer classes that allows for a custom token key.
This allows connecting to APIs that use a different token keys from the default ones.
Given that the common Client class already allows this, the new constructors just calls super with the received parameters.