### PR TITLE
Corrected Exception message for Keccak-256 hash function

### DIFF
--- a/src/main/java/com/algorand/algosdk/templates/HTLC.java
+++ b/src/main/java/com/algorand/algosdk/templates/HTLC.java
@@ -118,7 +118,7 @@ public class HTLC {
 				Keccak.Digest256 digest = new Keccak.Digest256();
 				byte[] computedImage = digest.digest(Encoder.decodeFromBase64(preImage));
 				if (Arrays.compareUnsigned(computedImage, hashImage) != 0) {
-					throw new RuntimeException("Unable to verify SHA-256 preImage: sha256(preimage) != image");
+					throw new RuntimeException("Unable to verify keccak256 preImage: keccak256(preimage) != image");
 				}
 			} catch (Exception e) {
 				// It's possible that the bouncy castle library is not loaded, in which case skip the validation.


### PR DESCRIPTION
The exception message generated when keccak256 is specified as the hash function for the HTLC(Hash Time Lock Contract) template was wrong so I corrected it.
Thanks