### PR TITLE
Added pretty print option to Object Mapper instance

### DIFF
--- a/src/main/java/com/algorand/algosdk/v2/client/common/PathResponse.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/common/PathResponse.java
@@ -14,7 +14,7 @@ public abstract class PathResponse {
     @Override
     public String toString() {
         try {
-            return mapper.writeValueAsString(this);
+            return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(this);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
             return null;


### PR DESCRIPTION
It is difficult to interpret and read the stringified json output of Objects extending the PathResponse class as the output appears in a single line and is not formatted.

Added the option to use default pretty printer to the object mapper instance so that the outputs appear as formatted json strings.  