### PR TITLE
Feature/sign rekey lsig msig

### DIFF
--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -87,6 +87,7 @@ public class Account {
         this.address = new Address(Arrays.copyOf(raw, raw.length));
     }
 
+    // Derive an Account from only private key
     public Account(PrivateKey pk) throws NoSuchAlgorithmException {
         CryptoProvider.setupIfNeeded();
         if (!pk.getAlgorithm().equals(KEY_ALGO))

--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -73,6 +73,16 @@ public class Account {
         this.address = new Address(Arrays.copyOf(raw, raw.length));
     }
 
+    // Derive an Account object from only keypair: {privateKey, publicKey}
+    public Account(KeyPair pkPair) {
+        if (!pkPair.getPrivate().getAlgorithm().equals(KEY_ALGO)) {
+            throw new IllegalArgumentException("Keypair algorithm do not match with expected " + KEY_ALGO);
+        }
+        this.privateKeyPair = pkPair;
+        byte[] raw = this.getClearTextPublicKey();
+        this.address = new Address(Arrays.copyOf(raw, raw.length));
+    }
+
     /**
      * Convenience method for getting the underlying public key for raw operations.
      * @return the public key as length 32 byte array.

--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -581,8 +581,7 @@ public class Account {
      * @param tx Transaction
      * @return SignedTransaction
      */
-    public static SignedTransaction signLogicsigTransaction(LogicsigSignature lsig, Transaction tx)
-            throws IllegalArgumentException, IOException {
+    public static SignedTransaction signLogicsigTransaction(LogicsigSignature lsig, Transaction tx) throws IllegalArgumentException, IOException {
         boolean hasSig = lsig.sig != null;
         boolean hasMsig = lsig.msig != null;
         Address lsigAddr;
@@ -596,7 +595,7 @@ public class Account {
             }
             return Account.signLogicTransactionWithAddress(lsig, lsigAddr, tx);
         } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalArgumentException("could not sign transaction", ex);
+            throw new IOException("could not sign transaction", ex);
         }
     }
 

--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -348,6 +348,10 @@ public class Account {
                     tx.mSig.threshold != merged.mSig.threshold) {
                 throw new IllegalArgumentException("transaction msig parameters do not match");
             }
+            // check that authAddr match
+            if (!tx.authAddr.equals(merged.authAddr)) {
+                throw new IllegalArgumentException("transaction msig auth addr do not match");
+            }
             for (int j = 0; j < tx.mSig.subsigs.size(); j++) {
                 MultisigSubsig myMsig = merged.mSig.subsigs.get(j);
                 MultisigSubsig theirMsig = tx.mSig.subsigs.get(j);

--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -523,6 +523,7 @@ public class Account {
      * @return SignedTransaction
      */
     public static SignedTransaction signLogicsigTransaction(LogicsigSignature lsig, Transaction tx) throws IllegalArgumentException, IOException {
+        // TODO need to rewrite somewhat
         if (!lsig.verify(tx.sender)) {
             throw new IllegalArgumentException("verification failed");
         }

--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -594,7 +594,7 @@ public class Account {
                 lsigAddr = lsig.toAddress();
             }
             return Account.signLogicTransactionWithAddress(lsig, lsigAddr, tx);
-        } catch (NoSuchAlgorithmException ex) {
+        } catch (Exception ex) {
             throw new IOException("could not sign transaction", ex);
         }
     }

--- a/src/main/java/com/algorand/algosdk/account/Account.java
+++ b/src/main/java/com/algorand/algosdk/account/Account.java
@@ -14,7 +14,6 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 
-import javax.annotation.Signed;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;

--- a/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
+++ b/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
@@ -1,6 +1,8 @@
 package com.algorand.algosdk.account;
 
 import com.algorand.algosdk.crypto.*;
+import com.algorand.algosdk.transaction.SignedTransaction;
+import com.algorand.algosdk.transaction.Transaction;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
@@ -56,7 +58,8 @@ public class LogicSigAccount {
 
     // The parameter signerPK must appear if LogicSig is delegated and the delegating account is backed by
     // a single private key (i.e., the delegating account is not a multi-sig account).
-    public LogicSigAccount(LogicsigSignature lsig, Ed25519PublicKey signerPk) throws IllegalArgumentException {
+    public LogicSigAccount(LogicsigSignature lsig, Ed25519PublicKey signerPk)
+            throws IllegalArgumentException, NoSuchAlgorithmException {
         boolean hasSig = lsig.sig != null;
         boolean hasMsig = lsig.msig != null;
         if (hasSig && hasMsig)
@@ -99,5 +102,10 @@ public class LogicSigAccount {
             return ma.toAddress();
         }
         return this.lsig.toAddress();
+    }
+
+    public SignedTransaction signLogicSigAccountTransaction(Transaction tx)
+            throws NoSuchAlgorithmException, IOException {
+        return Account.signLogicTransactionWithAddress(this.lsig, this.getAddress(), tx);
     }
 }

--- a/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
+++ b/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
@@ -16,8 +16,6 @@ public class LogicSigAccount {
 
     /**
      * Creates a new escrow LogicSig Account
-     * This type of LogicSigAccount has the authority to sign transaction on behalf of another account,
-     * or so to say that account delegate the transaction signing to the program.
      * The address of the account is the hash of its program (logic)
      * @param logic the bytes of program
      * @param args the arguments of the program

--- a/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
+++ b/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
@@ -11,24 +11,32 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class LogicSigAccount {
-    // TODO some private config stuffs...
-    private static final int PK_SIZE = 32;
-    private static final int PK_X509_PREFIX_LENGTH = 12; // Ed25519 specific
-
     public final Ed25519PublicKey sigKey;
     public final LogicsigSignature lsig;
 
-    // Create a new escrow LogicSigAccount.
-    // The address of the account is the hash of its program
+    /**
+     * Creates a new escrow LogicSig Account
+     * This type of LogicSigAccount has the authority to sign transaction on behalf of another account,
+     * or so to say that account delegate the transaction signing to the program.
+     * The address of the account is the hash of its program (logic)
+     * @param logic the bytes of program
+     * @param args the arguments of the program
+     **/
     public LogicSigAccount(byte[] logic, List<byte[]> args) {
         this.lsig = new LogicsigSignature(logic, args);
         this.sigKey = null;
     }
 
-    // Create a new delegated LogicSigAccount.
-    // This type of LogicSigAccount has the authority to sign transaction on behalf of another account,
-    // or so to say that account delegate the transaction signing to the program.
-    // If the delegating account is a multi-sig account, do not use this constructor.
+    /**
+     * Creates a new delegated LogicSigAccount.
+     * This type of LogicSigAccount has the authority to sign transaction on behalf of another account,
+     * or so to say that account delegate the transaction signing to the program.
+     * If the delegating account is a multi-sig account, please pass in a multi-address for class construction
+     * (do not use this constructor in that case)
+     * @param logic the bytes of program
+     * @param args the arguments of the program
+     * @param privateKey the (only) private key of the delegating account
+     **/
     public LogicSigAccount(byte[] logic, List<byte[]> args, PrivateKey privateKey)
             throws NoSuchAlgorithmException, IOException {
         this.lsig = new LogicsigSignature(logic, args);
@@ -40,8 +48,19 @@ public class LogicSigAccount {
         this.sigKey = signerAccount.getEd25519PublicKey();
     }
 
-    // Create a new delegated LogicSigAccount.
-    // The delegated Account here is a multi-sig account,
+    /**
+     * Creates a new delegated LogicSigAccount.
+     * This type of LogicSigAccount has the authority to sign transaction on behalf of another account,
+     * or so to say that account delegate the transaction signing to the program.
+     * The delegated Account here is a multi-sig account.
+     * To add additional signature from other member, use appendMultiSig method.
+     * @param logic the bytes of program
+     * @param args the arguments of the program
+     * @param privateKey is the private key of one of the member of delegating multi-sig account
+     * @param ma is the multi-sig-address of the delegating account.
+     * @throws IOException
+     * @throws NoSuchAlgorithmException
+     */
     public LogicSigAccount(byte[] logic, List<byte[]> args, PrivateKey privateKey, MultisigAddress ma)
             throws IOException, NoSuchAlgorithmException {
         this.lsig = new LogicsigSignature(logic, args);
@@ -50,41 +69,66 @@ public class LogicSigAccount {
         this.sigKey = null;
     }
 
+    /**
+     * Adds a signature from the delegating multi-sig account
+     * @param privateKey is the private key of one of the member of delegating multi-sig account
+     * @throws IllegalArgumentException
+     * @throws IOException
+     * @throws NoSuchAlgorithmException
+     */
     public void appendMultiSig(PrivateKey privateKey)
             throws IllegalArgumentException, IOException, NoSuchAlgorithmException {
         Account signerAccount = new Account(privateKey);
         signerAccount.appendToLogicsig(this.lsig);
     }
 
-    // The parameter signerPK must appear if LogicSig is delegated and the delegating account is backed by
-    // a single private key (i.e., the delegating account is not a multi-sig account).
-    public LogicSigAccount(LogicsigSignature lsig, Ed25519PublicKey signerPk)
+    /**
+     * Creates a new delegated LogicSigAccount from existing LogicSig
+     * @param lsig is an existing LogicSig.
+     * @param signerPublicKey must be present if the LogicSig is delegated and the delegating account
+     *                        is backed by a single private key (i.e. not a multi-sig account).
+     *                        It must be the public key of the delegating account, or an error will be returned
+     *                        if it is present.
+     * @throws IllegalArgumentException
+     * @throws NoSuchAlgorithmException
+     */
+    public LogicSigAccount(LogicsigSignature lsig, Ed25519PublicKey signerPublicKey)
             throws IllegalArgumentException, NoSuchAlgorithmException {
         boolean hasSig = lsig.sig != null;
         boolean hasMsig = lsig.msig != null;
         if (hasSig && hasMsig)
             throw new IllegalArgumentException("Logicsig has too many signatures, at most one of Sig or Msig may be defined");
         if (hasSig) {
-            if (signerPk == null)
+            if (signerPublicKey == null)
                 throw new IllegalArgumentException("Cannot generate LogicSigAccount from single-signed LogicSig and a null public key");
-            if (!lsig.verify(new Address(signerPk.getBytes())))
+            if (!lsig.verify(new Address(signerPublicKey.getBytes())))
                 throw new IllegalArgumentException("Cannot verify the sig in LogicSig with the public key provided");
             this.lsig = lsig;
-            this.sigKey = signerPk;
+            this.sigKey = signerPublicKey;
             return;
         }
-        if (signerPk != null)
+        if (signerPublicKey != null)
             throw new IllegalArgumentException("Cannot generate LogicSigAccount from multi-sig LogicSig and a public key");
         this.lsig = lsig;
         this.sigKey = null;
     }
 
+    /**
+     * IsDelegated returns true iff. the LogicSig has been delegated to another account with a signature
+     * @return boolean
+     */
     public boolean isDelegated() {
         boolean hasSig = this.lsig.sig != null;
         boolean hasMsig = this.lsig.msig != null;
         return hasSig || hasMsig;
     }
 
+    /**
+     * getAddress returns the address of the LogicSigAccount
+     * @return the address of the LogicSigAccount
+     * @throws NoSuchAlgorithmException
+     * @throws IllegalArgumentException
+     */
     public Address getAddress() throws NoSuchAlgorithmException, IllegalArgumentException {
         boolean hasSig = this.lsig.sig != null;
         boolean hasMsig = this.lsig.msig != null;
@@ -104,6 +148,13 @@ public class LogicSigAccount {
         return this.lsig.toAddress();
     }
 
+    /**
+     * Sign a transaction with this account
+     * @param tx transaction
+     * @return signed transaction from LogicSigAccount
+     * @throws NoSuchAlgorithmException
+     * @throws IOException
+     */
     public SignedTransaction signLogicSigTransaction(Transaction tx)
             throws NoSuchAlgorithmException, IOException {
         return Account.signLogicTransactionWithAddress(this.lsig, this.getAddress(), tx);

--- a/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
+++ b/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
@@ -3,8 +3,8 @@ package com.algorand.algosdk.account;
 import com.algorand.algosdk.crypto.*;
 
 import java.io.IOException;
-import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,17 +20,17 @@ public class LogicSigAccount {
     // The address of the account is the hash of its program
     public LogicSigAccount(byte[] logic, List<byte[]> args) {
         this.lsig = new LogicsigSignature(logic, args);
-        this.sigKey = new Ed25519PublicKey();
+        this.sigKey = null;
     }
 
     // Create a new delegated LogicSigAccount.
     // This type of LogicSigAccount has the authority to sign transaction on behalf of another account,
     // or so to say that account delegate the transaction signing to the program.
     // If the delegating account is a multi-sig account, do not use this constructor.
-    public LogicSigAccount(byte[] logic, List<byte[]> args, KeyPair privateKeyPair) throws NoSuchAlgorithmException {
+    public LogicSigAccount(byte[] logic, List<byte[]> args, PrivateKey privateKey) throws NoSuchAlgorithmException {
         this.lsig = new LogicsigSignature(logic, args);
         // Generate delegated Account from private keypair
-        Account signerAccount = new Account(privateKeyPair);
+        Account signerAccount = new Account(privateKey);
         // Sign program bytes from delegated account, and add to LogicSig
         this.lsig.sig = signerAccount.signBytes(this.lsig.bytesToSign());
         // set signing public key of the delegated account
@@ -39,40 +39,41 @@ public class LogicSigAccount {
 
     // Create a new delegated LogicSigAccount.
     // The delegated Account here is a multi-sig account,
-    public LogicSigAccount(byte[] logic, List<byte[]> args, MultisigAddress ma, KeyPair privateKeyPair) throws IOException {
+    public LogicSigAccount(byte[] logic, List<byte[]> args, MultisigAddress ma, PrivateKey privateKey)
+            throws IOException, NoSuchAlgorithmException {
         this.lsig = new LogicsigSignature(logic, args);
-        Account signerAccount = new Account(privateKeyPair);
+        Account signerAccount = new Account(privateKey);
         signerAccount.signLogicsig(this.lsig, ma);
-        this.sigKey = new Ed25519PublicKey();
+        this.sigKey = null;
     }
 
-    public void appendMultiSig(KeyPair privateKeyPair) throws IllegalArgumentException, IOException {
-        Account signerAccount = new Account(privateKeyPair);
+    public void appendMultiSig(PrivateKey privateKey)
+            throws IllegalArgumentException, IOException, NoSuchAlgorithmException {
+        Account signerAccount = new Account(privateKey);
         signerAccount.appendToLogicsig(this.lsig);
     }
 
+    // The parameter signerPK must appear if LogicSig is delegated and the delegating account is backed by
+    // a single private key (i.e., the delegating account is not a multi-sig account).
     public LogicSigAccount(LogicsigSignature lsig, Ed25519PublicKey signerPk) throws IllegalArgumentException {
-        boolean hasSig = !lsig.sig.equals(new Signature());
-        boolean hasMsig = !lsig.msig.equals(new MultisigSignature(0, 0));
+        boolean hasSig = lsig.sig != null;
+        boolean hasMsig = lsig.msig != null;
         if (hasSig && hasMsig) {
             throw new IllegalArgumentException("Logicsig has too many signatures, at most one of Sig or Msig may be defined");
         }
-        if (hasMsig && !signerPk.equals(new Ed25519PublicKey())) {
+        if (hasMsig && signerPk != null) {
             throw new IllegalArgumentException("Cannot generate LogicSigAccount from multi-sig LogicSig and a public key");
         }
         if (hasSig) {
-            if (signerPk.equals(new Ed25519PublicKey())) {
+            if (signerPk == null) {
                 throw new IllegalArgumentException("Cannot generate LogicSigAccount from single-signed LogicSig and a null public key");
             }
             if (!lsig.verify(new Address(signerPk.getBytes()))) {
                 throw new IllegalArgumentException("Cannot verify the sig in LogicSig with the public key provided");
             }
-            this.lsig = lsig;
-            this.sigKey = signerPk;
-            return;
         }
         this.lsig = lsig;
-        this.sigKey = new Ed25519PublicKey();
+        this.sigKey = signerPk;
     }
 
     public boolean isDelegated() {

--- a/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
+++ b/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
@@ -104,7 +104,7 @@ public class LogicSigAccount {
         return this.lsig.toAddress();
     }
 
-    public SignedTransaction signLogicSigAccountTransaction(Transaction tx)
+    public SignedTransaction signLogicSigTransaction(Transaction tx)
             throws NoSuchAlgorithmException, IOException {
         return Account.signLogicTransactionWithAddress(this.lsig, this.getAddress(), tx);
     }

--- a/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
+++ b/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
@@ -1,0 +1,104 @@
+package com.algorand.algosdk.account;
+
+import com.algorand.algosdk.crypto.*;
+
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LogicSigAccount {
+    // TODO some private config stuffs...
+    private static final int PK_SIZE = 32;
+    private static final int PK_X509_PREFIX_LENGTH = 12; // Ed25519 specific
+
+    public final Ed25519PublicKey sigKey;
+    public final LogicsigSignature lsig;
+
+    // Create a new escrow LogicSigAccount.
+    // The address of the account is the hash of its program
+    public LogicSigAccount(byte[] logic, List<byte[]> args) {
+        this.lsig = new LogicsigSignature(logic, args);
+        this.sigKey = new Ed25519PublicKey();
+    }
+
+    // Create a new delegated LogicSigAccount.
+    // This type of LogicSigAccount has the authority to sign transaction on behalf of another account,
+    // or so to say that account delegate the transaction signing to the program.
+    // If the delegating account is a multi-sig account, do not use this constructor.
+    public LogicSigAccount(byte[] logic, List<byte[]> args, KeyPair privateKeyPair) throws NoSuchAlgorithmException {
+        this.lsig = new LogicsigSignature(logic, args);
+        // Generate delegated Account from private keypair
+        Account signerAccount = new Account(privateKeyPair);
+        // Sign program bytes from delegated account, and add to LogicSig
+        this.lsig.sig = signerAccount.signBytes(this.lsig.bytesToSign());
+        // set signing public key of the delegated account
+        this.sigKey = signerAccount.getEd25519PublicKey();
+    }
+
+    // Create a new delegated LogicSigAccount.
+    // The delegated Account here is a multi-sig account,
+    public LogicSigAccount(byte[] logic, List<byte[]> args, MultisigAddress ma, KeyPair privateKeyPair) throws IOException {
+        this.lsig = new LogicsigSignature(logic, args);
+        Account signerAccount = new Account(privateKeyPair);
+        signerAccount.signLogicsig(this.lsig, ma);
+        this.sigKey = new Ed25519PublicKey();
+    }
+
+    public void appendMultiSig(KeyPair privateKeyPair) throws IllegalArgumentException, IOException {
+        Account signerAccount = new Account(privateKeyPair);
+        signerAccount.appendToLogicsig(this.lsig);
+    }
+
+    public LogicSigAccount(LogicsigSignature lsig, Ed25519PublicKey signerPk) throws IllegalArgumentException {
+        boolean hasSig = !lsig.sig.equals(new Signature());
+        boolean hasMsig = !lsig.msig.equals(new MultisigSignature(0, 0));
+        if (hasSig && hasMsig) {
+            throw new IllegalArgumentException("Logicsig has too many signatures, at most one of Sig or Msig may be defined");
+        }
+        if (hasMsig && !signerPk.equals(new Ed25519PublicKey())) {
+            throw new IllegalArgumentException("Cannot generate LogicSigAccount from multi-sig LogicSig and a public key");
+        }
+        if (hasSig) {
+            if (signerPk.equals(new Ed25519PublicKey())) {
+                throw new IllegalArgumentException("Cannot generate LogicSigAccount from single-signed LogicSig and a null public key");
+            }
+            if (!lsig.verify(new Address(signerPk.getBytes()))) {
+                throw new IllegalArgumentException("Cannot verify the sig in LogicSig with the public key provided");
+            }
+            this.lsig = lsig;
+            this.sigKey = signerPk;
+            return;
+        }
+        this.lsig = lsig;
+        this.sigKey = new Ed25519PublicKey();
+    }
+
+    public boolean isDelegated() {
+        boolean hasSig = !this.lsig.sig.equals(new Signature());
+        boolean hasMsig = !this.lsig.msig.equals(new MultisigSignature(0, 0));
+        return hasSig || hasMsig;
+    }
+
+    public Address getAddress() throws NoSuchAlgorithmException, IllegalArgumentException {
+        boolean hasSig = !this.lsig.sig.equals(new Signature());
+        boolean hasMsig = !this.lsig.msig.equals(new MultisigSignature(0, 0));
+        if (hasSig && hasMsig) {
+            throw new IllegalArgumentException("Logicsig has too many signatures, at most one of Sig or Msig may be defined");
+        }
+        if (hasSig) {
+            byte[] sigKeyRaw = this.sigKey.getBytes();
+            return new Address(sigKeyRaw);
+        }
+        if (hasMsig) {
+            List<Ed25519PublicKey> pkFromSubSig = new ArrayList<Ed25519PublicKey>();
+            for (MultisigSignature.MultisigSubsig subSig : this.lsig.msig.subsigs) {
+                pkFromSubSig.add(subSig.key);
+            }
+            MultisigAddress ma = new MultisigAddress(this.lsig.msig.version, this.lsig.msig.threshold, pkFromSubSig);
+            return ma.toAddress();
+        }
+        return this.lsig.toAddress();
+    }
+}

--- a/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
+++ b/src/main/java/com/algorand/algosdk/account/LogicSigAccount.java
@@ -27,19 +27,20 @@ public class LogicSigAccount {
     // This type of LogicSigAccount has the authority to sign transaction on behalf of another account,
     // or so to say that account delegate the transaction signing to the program.
     // If the delegating account is a multi-sig account, do not use this constructor.
-    public LogicSigAccount(byte[] logic, List<byte[]> args, PrivateKey privateKey) throws NoSuchAlgorithmException {
+    public LogicSigAccount(byte[] logic, List<byte[]> args, PrivateKey privateKey)
+            throws NoSuchAlgorithmException, IOException {
         this.lsig = new LogicsigSignature(logic, args);
         // Generate delegated Account from private keypair
         Account signerAccount = new Account(privateKey);
         // Sign program bytes from delegated account, and add to LogicSig
-        this.lsig.sig = signerAccount.signBytes(this.lsig.bytesToSign());
+        signerAccount.signLogicsig(this.lsig);
         // set signing public key of the delegated account
         this.sigKey = signerAccount.getEd25519PublicKey();
     }
 
     // Create a new delegated LogicSigAccount.
     // The delegated Account here is a multi-sig account,
-    public LogicSigAccount(byte[] logic, List<byte[]> args, MultisigAddress ma, PrivateKey privateKey)
+    public LogicSigAccount(byte[] logic, List<byte[]> args, PrivateKey privateKey, MultisigAddress ma)
             throws IOException, NoSuchAlgorithmException {
         this.lsig = new LogicsigSignature(logic, args);
         Account signerAccount = new Account(privateKey);
@@ -58,45 +59,42 @@ public class LogicSigAccount {
     public LogicSigAccount(LogicsigSignature lsig, Ed25519PublicKey signerPk) throws IllegalArgumentException {
         boolean hasSig = lsig.sig != null;
         boolean hasMsig = lsig.msig != null;
-        if (hasSig && hasMsig) {
+        if (hasSig && hasMsig)
             throw new IllegalArgumentException("Logicsig has too many signatures, at most one of Sig or Msig may be defined");
-        }
-        if (hasMsig && signerPk != null) {
-            throw new IllegalArgumentException("Cannot generate LogicSigAccount from multi-sig LogicSig and a public key");
-        }
         if (hasSig) {
-            if (signerPk == null) {
+            if (signerPk == null)
                 throw new IllegalArgumentException("Cannot generate LogicSigAccount from single-signed LogicSig and a null public key");
-            }
-            if (!lsig.verify(new Address(signerPk.getBytes()))) {
+            if (!lsig.verify(new Address(signerPk.getBytes())))
                 throw new IllegalArgumentException("Cannot verify the sig in LogicSig with the public key provided");
-            }
+            this.lsig = lsig;
+            this.sigKey = signerPk;
+            return;
         }
+        if (signerPk != null)
+            throw new IllegalArgumentException("Cannot generate LogicSigAccount from multi-sig LogicSig and a public key");
         this.lsig = lsig;
-        this.sigKey = signerPk;
+        this.sigKey = null;
     }
 
     public boolean isDelegated() {
-        boolean hasSig = !this.lsig.sig.equals(new Signature());
-        boolean hasMsig = !this.lsig.msig.equals(new MultisigSignature(0, 0));
+        boolean hasSig = this.lsig.sig != null;
+        boolean hasMsig = this.lsig.msig != null;
         return hasSig || hasMsig;
     }
 
     public Address getAddress() throws NoSuchAlgorithmException, IllegalArgumentException {
-        boolean hasSig = !this.lsig.sig.equals(new Signature());
-        boolean hasMsig = !this.lsig.msig.equals(new MultisigSignature(0, 0));
-        if (hasSig && hasMsig) {
+        boolean hasSig = this.lsig.sig != null;
+        boolean hasMsig = this.lsig.msig != null;
+        if (hasSig && hasMsig)
             throw new IllegalArgumentException("Logicsig has too many signatures, at most one of Sig or Msig may be defined");
-        }
         if (hasSig) {
             byte[] sigKeyRaw = this.sigKey.getBytes();
             return new Address(sigKeyRaw);
         }
         if (hasMsig) {
-            List<Ed25519PublicKey> pkFromSubSig = new ArrayList<Ed25519PublicKey>();
-            for (MultisigSignature.MultisigSubsig subSig : this.lsig.msig.subsigs) {
+            List<Ed25519PublicKey> pkFromSubSig = new ArrayList<>();
+            for (MultisigSignature.MultisigSubsig subSig : this.lsig.msig.subsigs)
                 pkFromSubSig.add(subSig.key);
-            }
             MultisigAddress ma = new MultisigAddress(this.lsig.msig.version, this.lsig.msig.threshold, pkFromSubSig);
             return ma.toAddress();
         }

--- a/src/main/java/com/algorand/algosdk/crypto/Address.java
+++ b/src/main/java/com/algorand/algosdk/crypto/Address.java
@@ -184,11 +184,7 @@ public class Address implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof Address && Arrays.equals(this.bytes, ((Address)obj).bytes)) {
-            return true;
-        } else {
-            return false;
-        }
+        return obj instanceof Address && Arrays.equals(this.bytes, ((Address) obj).bytes);
     }
     
     // Compare to an address, with default address considered as empty string

--- a/src/main/java/com/algorand/algosdk/crypto/Ed25519PublicKey.java
+++ b/src/main/java/com/algorand/algosdk/crypto/Ed25519PublicKey.java
@@ -44,10 +44,6 @@ public class Ed25519PublicKey implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof Ed25519PublicKey && Arrays.equals(this.bytes, ((Ed25519PublicKey)obj).bytes)) {
-            return true;
-        } else {
-            return false;
-        }
+        return obj instanceof Ed25519PublicKey && Arrays.equals(this.bytes, ((Ed25519PublicKey) obj).bytes);
     }
 }

--- a/src/main/java/com/algorand/algosdk/crypto/LogicsigSignature.java
+++ b/src/main/java/com/algorand/algosdk/crypto/LogicsigSignature.java
@@ -41,10 +41,10 @@ public class LogicsigSignature {
 
     @JsonCreator
     public LogicsigSignature(
-            @JsonProperty("l") byte[] logic,
-            @JsonProperty("arg") List<byte[]> args,
-            @JsonProperty("sig") byte[] sig,
-            @JsonProperty("msig") MultisigSignature msig
+        @JsonProperty("l") byte[] logic,
+        @JsonProperty("arg") List<byte[]> args,
+        @JsonProperty("sig") byte[] sig,
+        @JsonProperty("msig") MultisigSignature msig
     ) {
         this.logic = Objects.requireNonNull(logic, "program must not be null");
         this.args = args;
@@ -63,7 +63,6 @@ public class LogicsigSignature {
 
     /**
      * Unsigned logicsig object.
-     *
      * @param logicsig
      */
     public LogicsigSignature(byte[] logicsig) {
@@ -72,7 +71,6 @@ public class LogicsigSignature {
 
     /**
      * Unsigned logicsig object, and its arguments.
-     *
      * @param logicsig
      * @param args
      */
@@ -90,7 +88,8 @@ public class LogicsigSignature {
 
     /**
      * Calculate escrow address from logic sig program
-     *
+     * NOTE: THIS RETURNS AN ESCROW ACCOUNT OF A LOGIC-SIG (FROM LOGIC ITSELF),
+     *       IT WILL NOT RETURN THE DELEGATED ADDRESS OF THE LOGIC-SIG.
      * @return Address
      * @throws NoSuchAlgorithmException
      */
@@ -101,7 +100,6 @@ public class LogicsigSignature {
 
     /**
      * Return prefixed program as byte array that is ready to sign
-     *
      * @return byte[]
      */
     public byte[] bytesToSign() {
@@ -113,7 +111,6 @@ public class LogicsigSignature {
 
     /**
      * Perform signature verification against the sender address
-     *
      * @param address Address to verify
      * @return boolean
      */

--- a/src/main/java/com/algorand/algosdk/crypto/LogicsigSignature.java
+++ b/src/main/java/com/algorand/algosdk/crypto/LogicsigSignature.java
@@ -41,10 +41,10 @@ public class LogicsigSignature {
 
     @JsonCreator
     public LogicsigSignature(
-        @JsonProperty("l") byte[] logic,
-        @JsonProperty("arg") List<byte[]> args,
-        @JsonProperty("sig") byte[] sig,
-        @JsonProperty("msig") MultisigSignature msig
+            @JsonProperty("l") byte[] logic,
+            @JsonProperty("arg") List<byte[]> args,
+            @JsonProperty("sig") byte[] sig,
+            @JsonProperty("msig") MultisigSignature msig
     ) {
         this.logic = Objects.requireNonNull(logic, "program must not be null");
         this.args = args;
@@ -55,7 +55,7 @@ public class LogicsigSignature {
             throw new IllegalArgumentException("invalid program", ex);
         }
 
-        assert verified == true;
+        assert verified;
 
         if (sig != null) this.sig = new Signature(sig);
         this.msig = msig;
@@ -63,6 +63,7 @@ public class LogicsigSignature {
 
     /**
      * Unsigned logicsig object.
+     *
      * @param logicsig
      */
     public LogicsigSignature(byte[] logicsig) {
@@ -71,6 +72,7 @@ public class LogicsigSignature {
 
     /**
      * Unsigned logicsig object, and its arguments.
+     *
      * @param logicsig
      * @param args
      */
@@ -88,6 +90,7 @@ public class LogicsigSignature {
 
     /**
      * Calculate escrow address from logic sig program
+     *
      * @return Address
      * @throws NoSuchAlgorithmException
      */
@@ -98,6 +101,7 @@ public class LogicsigSignature {
 
     /**
      * Return prefixed program as byte array that is ready to sign
+     *
      * @return byte[]
      */
     public byte[] bytesToSign() {
@@ -109,6 +113,7 @@ public class LogicsigSignature {
 
     /**
      * Perform signature verification against the sender address
+     *
      * @param address Address to verify
      * @return boolean
      */
@@ -158,9 +163,7 @@ public class LogicsigSignature {
 
     private static boolean nullCheck(Object o1, Object o2) {
         if (o1 == null && o2 == null) return true;
-        if (o1 == null && o2 != null) return false;
-        if (o1 != null && o2 == null) return false;
-        return true;
+        else return o1 != null && o2 != null;
     }
 
     @Override
@@ -183,9 +186,7 @@ public class LogicsigSignature {
             if (this.sig != null && !this.sig.equals(actual.sig)) return false;
 
             if (!LogicsigSignature.nullCheck(this.msig, actual.msig)) return false;
-            if (this.msig != null && !this.msig.equals(actual.msig)) return false;
-
-            return true;
+            return this.msig == null || this.msig.equals(actual.msig);
         } else {
             return false;
         }

--- a/src/main/java/com/algorand/algosdk/crypto/LogicsigSignature.java
+++ b/src/main/java/com/algorand/algosdk/crypto/LogicsigSignature.java
@@ -111,10 +111,11 @@ public class LogicsigSignature {
 
     /**
      * Perform signature verification against the sender address
-     * @param address Address to verify
+     * @param singleSigner only used in the case of a delegated LogicSig whose delegating account
+     *                     is backed by a single private key
      * @return boolean
      */
-    public boolean verify(Address address) {
+    public boolean verify(Address singleSigner) throws NoSuchAlgorithmException {
         if (this.logic == null) {
             return false;
         }
@@ -129,17 +130,9 @@ public class LogicsigSignature {
             return false;
         }
 
-        if (this.sig == null && this.msig == null) {
-            try {
-                return address.equals(this.toAddress());
-            } catch (NoSuchAlgorithmException e) {
-                return false;
-            }
-        }
-
         PublicKey pk;
         try {
-            pk = address.toVerifyKey();
+            pk = singleSigner.toVerifyKey();
         } catch (Exception ex) {
             return false;
         }
@@ -155,7 +148,10 @@ public class LogicsigSignature {
             }
         }
 
-        return this.msig.verify(this.bytesToSign());
+        if (this.msig != null)
+            return this.msig.verify(this.bytesToSign());
+
+        return true;
     }
 
     private static boolean nullCheck(Object o1, Object o2) {

--- a/src/main/java/com/algorand/algosdk/crypto/MultisigSignature.java
+++ b/src/main/java/com/algorand/algosdk/crypto/MultisigSignature.java
@@ -128,10 +128,7 @@ public class MultisigSignature implements Serializable {
                 }
             }
         }
-        if (verifiedCount < this.threshold) {
-            return false;
-        }
-        return true;
+        return verifiedCount >= this.threshold;
     }
 
     @Override

--- a/src/main/java/com/algorand/algosdk/crypto/MultisigSignature.java
+++ b/src/main/java/com/algorand/algosdk/crypto/MultisigSignature.java
@@ -131,6 +131,14 @@ public class MultisigSignature implements Serializable {
         return verifiedCount >= this.threshold;
     }
 
+    public MultisigAddress convertToMultisigAddress() {
+        List<Ed25519PublicKey> pubK = new ArrayList<>();
+        for (MultisigSubsig sig : this.subsigs) {
+            pubK.add(sig.key);
+        }
+        return new MultisigAddress(this.version, this.threshold, pubK);
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof MultisigSignature) {

--- a/src/main/java/com/algorand/algosdk/crypto/Signature.java
+++ b/src/main/java/com/algorand/algosdk/crypto/Signature.java
@@ -44,10 +44,6 @@ public class Signature implements Serializable {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof Signature && Arrays.equals(this.bytes, ((Signature)obj).bytes)) {
-            return true;
-        } else {
-            return false;
-        }
+        return obj instanceof Signature && Arrays.equals(this.bytes, ((Signature) obj).bytes);
     }
 }

--- a/src/test/java/com/algorand/algosdk/account/TestAccount.java
+++ b/src/test/java/com/algorand/algosdk/account/TestAccount.java
@@ -5,24 +5,15 @@ import com.algorand.algosdk.crypto.Signature;
 import com.algorand.algosdk.mnemonic.Mnemonic;
 import com.algorand.algosdk.transaction.SignedTransaction;
 import com.algorand.algosdk.transaction.Transaction;
-import com.algorand.algosdk.util.CryptoProvider;
 import com.algorand.algosdk.util.Encoder;
 import com.google.common.primitives.Bytes;
-import io.cucumber.java.bs.A;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.bouncycastle.math.ec.rfc8032.Ed25519;
 import org.bouncycastle.util.test.FixedSecureRandom;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Signed;
-import javax.crypto.spec.SecretKeySpec;
-import java.lang.reflect.Array;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.ByteBuffer;
 import java.security.*;
-import java.security.spec.EncodedKeySpec;
-import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Random;
@@ -355,7 +346,7 @@ public class TestAccount {
         Account account = new Account();
         Signature signature = account.signBytes(b);
         assertThat(account.getAddress().verifyBytes(b, signature)).isTrue();
-        int firstByte = (int) b[0];
+        int firstByte = b[0];
         firstByte = (firstByte+1) % 256;
         b[0] = (byte) firstByte;
         assertThat(account.getAddress().verifyBytes(b, signature)).isFalse();
@@ -367,7 +358,7 @@ public class TestAccount {
         Signature signature = new Signature(Encoder.decodeFromBase64("COEBmoD+ysVECoyVOAsvMAjFxvKeQVkYld+RSHMnEiHsypqrfj2EdYqhrm4t7dK3ZOeSQh3aXiZK/zqQDTPBBw=="));
         Address address = new Address("DPLD3RTSWC5STVBPZL5DIIVE2OC4BSAWTOYBLFN2X6EFLT2ZNF4SMX64UA");
         assertThat(address.verifyBytes(message, signature)).isTrue();
-        int firstByte = (int) message[0];
+        int firstByte = message[0];
         firstByte = (firstByte+1) % 256;
         message[0] = (byte) firstByte;
         assertThat(address.verifyBytes(message, signature)).isFalse();
@@ -429,7 +420,7 @@ public class TestAccount {
             0x01, 0x20, 0x01, 0x01, 0x22  // int 1
         };
 
-        ArrayList<byte[]> args = new ArrayList<byte[]>();
+        ArrayList<byte[]> args = new ArrayList<>();
         byte[] arg1 = {49, 50, 51};
         byte[] arg2 = {52, 53, 54};
         args.add(arg1);
@@ -461,7 +452,7 @@ public class TestAccount {
 
         PublicKey pk = acc.getAddress().toVerifyKey();
 
-        boolean verified = false;
+        boolean verified;
         try {
             java.security.Signature sig = java.security.Signature.getInstance("EdDSA");
             sig.initVerify(pk);

--- a/src/test/java/com/algorand/algosdk/account/TestAccount.java
+++ b/src/test/java/com/algorand/algosdk/account/TestAccount.java
@@ -476,7 +476,7 @@ public class TestAccount {
         assertThat(account.toSeed()).isEqualTo(seed);
     }
 
-    public static class TestLpgicSigTransaction {
+    public static class TestLogicSigTransaction {
         byte[] program;
         ArrayList<byte[]> args;
         String otherAddrStr, programHash;

--- a/src/test/java/com/algorand/algosdk/account/TestLogicSigAccount.java
+++ b/src/test/java/com/algorand/algosdk/account/TestLogicSigAccount.java
@@ -1,20 +1,167 @@
 package com.algorand.algosdk.account;
 
+import com.algorand.algosdk.crypto.*;
+import com.algorand.algosdk.crypto.Signature;
+import com.algorand.algosdk.mnemonic.Mnemonic;
+import org.bouncycastle.util.test.FixedSecureRandom;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.security.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.*;
+
+
 public class TestLogicSigAccount {
-    @Test
-    public void testLogicSigAccount() {
+    byte[] program;
+    ArrayList<byte[]> args;
+    final String SK_MNEMONIC = "olympic cricket tower model share zone grid twist sponsor avoid eight apology patient party success claim famous rapid donor pledge bomb mystery security ability often";
+    Account singleDelegateAccount;
+    KeyPair kp;
 
+    MultisigAddress ma;
+    KeyPair maKp0, maKp1, maKp2;
+
+    private KeyPair mnemonicToKeyPair(String mnemonic) throws GeneralSecurityException {
+        byte[] seed = Mnemonic.toKey(mnemonic);
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("Ed25519");
+        gen.initialize(256, new FixedSecureRandom(seed));
+        return gen.generateKeyPair();
+    }
+
+    @BeforeEach
+    void setUp() throws GeneralSecurityException {
+        program = new byte[]{0x01, 0x20, 0x01, 0x01, 0x22};
+        args = new ArrayList<>();
+        byte[] arg0 = {0x01};
+        byte[] arg1 = {0x02, 0x03};
+        args.add(arg0);
+        args.add(arg1);
+
+        byte[] seed = Mnemonic.toKey(SK_MNEMONIC);
+        singleDelegateAccount = new Account(seed);
+        kp = mnemonicToKeyPair(SK_MNEMONIC);
+
+        Address one = new Address("DN7MBMCL5JQ3PFUQS7TMX5AH4EEKOBJVDUF4TCV6WERATKFLQF4MQUPZTA");
+        Address two = new Address("BFRTECKTOOE7A5LHCF3TTEOH2A7BW46IYT2SX5VP6ANKEXHZYJY77SJTVM");
+        Address three = new Address("47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU");
+        ma = new MultisigAddress(1, 2, Arrays.asList(
+                new Ed25519PublicKey(one.getBytes()),
+                new Ed25519PublicKey(two.getBytes()),
+                new Ed25519PublicKey(three.getBytes())
+        ));
+        maKp0 = mnemonicToKeyPair("auction inquiry lava second expand liberty glass involve ginger illness length room item discover ahead table doctor term tackle cement bonus profit right above catch");
+        maKp1 = mnemonicToKeyPair("since during average anxiety protect cherry club long lawsuit loan expand embark forum theory winter park twenty ball kangaroo cram burst board host ability left");
+        maKp2 = mnemonicToKeyPair("advice pudding treat near rule blouse same whisper inner electric quit surface sunny dismiss leader blood seat clown cost exist hospital century reform able sponsor");
     }
 
     @Test
-    public void testLogicSigAccountFromLogicSig() {
+    public void testLogicSigAccount() throws Exception {
+        // escrow logic-sig account
+        LogicSigAccount lsaEscrow = new LogicSigAccount(program, args);
+        assertThat(lsaEscrow.lsig).isEqualTo(new LogicsigSignature(program, args));
+        assertThat(lsaEscrow.sigKey).isNull();
 
+        // delegated single logic-sig account
+        LogicSigAccount lsaDelegated = new LogicSigAccount(program, args, kp.getPrivate());
+        byte[] expectedSigBytes = new byte[]{
+                0x3e, 0x5, 0x3d, 0x39, 0x4d, (byte) 0xfb, 0x12, (byte) 0xbc, 0x65, 0x79,
+                (byte) 0x9f, (byte) 0xea, 0x31, (byte) 0x8a, 0x7b, (byte) 0x8e, (byte) 0xa2,
+                (byte) 0x51, (byte) 0x8b, 0x55, 0x2c, (byte) 0x8a, (byte) 0xbe, 0x6c, (byte) 0xd7,
+                (byte) 0xa7, 0x65, 0x2d, (byte) 0xd8, (byte) 0xb0, 0x18, 0x7e, 0x21, 0x5, 0x2d,
+                (byte) 0xb9, 0x24, 0x62, (byte) 0x89, 0x16, (byte) 0xe5, 0x61, 0x74, (byte) 0xcd,
+                0xf, 0x19, (byte) 0xac, (byte) 0xb9, 0x6c, 0x45, (byte) 0xa4, 0x29, (byte) 0x91,
+                (byte) 0x99, 0x11, 0x1d, (byte) 0xe4, 0x7c, (byte) 0xe4, (byte) 0xfc, 0x12,
+                (byte) 0xec, (byte) 0xce, 0x2
+        };
+        assertThat(lsaDelegated.sigKey).isEqualTo(singleDelegateAccount.getEd25519PublicKey());
+        assertThat(lsaDelegated.lsig.msig).isNull();
+        assertThat(singleDelegateAccount.getEd25519PublicKey()).isEqualTo(lsaDelegated.sigKey);
+        assertThat(lsaDelegated.lsig.sig).isEqualTo(new Signature(expectedSigBytes));
+
+        // delegated multi logic-sig account
+        LogicSigAccount lsaMultiDelegated = new LogicSigAccount(program, args, maKp0.getPrivate(), ma);
+        assertThat(lsaMultiDelegated.sigKey).isNull();
+        assertThat(lsaMultiDelegated.lsig.logic).isEqualTo(program);
+        assertThat(lsaMultiDelegated.lsig.args).isEqualTo(args);
+        lsaMultiDelegated.appendMultiSig(maKp1.getPrivate());
+
+        byte[] sig0bytes = new byte[]{
+                0x49, 0x13, (byte) 0xb8, 0x5, (byte) 0xd1, (byte) 0x9e, 0x7f, 0x2c, 0x10, (byte) 0x80, (byte) 0xf6,
+                0x33, 0x7e, 0x18, 0x54, (byte) 0xa7, (byte) 0xce, (byte) 0xea, (byte) 0xee, 0x10, (byte) 0xdd, (byte) 0xbd,
+                0x13, 0x65, (byte) 0x84, (byte) 0xbf, (byte) 0x93, (byte) 0xb7, 0x5f, 0x30, 0x63, 0x15, (byte) 0x91,
+                (byte) 0xca, 0x23, 0xc, (byte) 0xed, (byte) 0xef, 0x23, (byte) 0xd1, 0x74, 0x1b, 0x52, (byte) 0x9d,
+                (byte) 0xb0, (byte) 0xff, (byte) 0xef, 0x37, 0x54, (byte) 0xd6, 0x46, (byte) 0xf4, (byte) 0xb5, 0x61,
+                (byte) 0xfc, (byte) 0x8b, (byte) 0xbc, 0x2d, 0x7b, 0x4e, 0x63, 0x5c, (byte) 0xbd, 0x2
+        };
+        Signature sig0Expected = new Signature(sig0bytes);
+        assertThat(lsaMultiDelegated.lsig.msig.subsigs.get(0).sig).isEqualTo(sig0Expected);
+
+        byte[] sig1bytes = new byte[]{
+                0x64, (byte) 0xbc, 0x55, (byte) 0xdb, (byte) 0xed, (byte) 0x91, (byte) 0xa2, 0x41, (byte) 0xd4, 0x2a,
+                (byte) 0xb6, 0x60, (byte) 0xf7, (byte) 0xe1, 0x4a, (byte) 0xb9, (byte) 0x99, (byte) 0x9a, 0x52,
+                (byte) 0xb3, (byte) 0xb1, 0x71, 0x58, (byte) 0xce, (byte) 0xfc, 0x3f, 0x4f, (byte) 0xe7,
+                (byte) 0xcb, 0x22, 0x41, 0x14, (byte) 0xad, (byte) 0xa9, 0x3d, 0x5e, (byte) 0x84, 0x5, 0x2, 0xa, 0x17,
+                (byte) 0xa6, 0x69, (byte) 0x83, 0x3, 0x22, 0x4e, (byte) 0x86, (byte) 0xa3, (byte) 0x8b, 0x6a, 0x36,
+                (byte) 0xc5, 0x54, (byte) 0xbe, 0x20, 0x50, (byte) 0xff, (byte) 0xd3, (byte) 0xee, (byte) 0xa8,
+                (byte) 0xb3, 0x4, 0x9
+        };
+        Signature sig1Expected = new Signature(sig1bytes);
+        assertThat(lsaMultiDelegated.lsig.msig.subsigs.get(1).sig).isEqualTo(sig1Expected);
     }
 
     @Test
-    public void testLogicSigAccountAddress() {
+    public void testLogicSigAccountFromLogicSig() throws IOException {
+        // escrow logic-sig account
+        LogicsigSignature lsigNoKey = new LogicsigSignature(program, args);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LogicSigAccount(lsigNoKey, singleDelegateAccount.getEd25519PublicKey()));
+        LogicSigAccount lsaNoKey = new LogicSigAccount(lsigNoKey, null);
+        assertThat(lsaNoKey.lsig).isEqualTo(lsigNoKey);
+        assertThat(lsaNoKey.sigKey).isNull();
 
+        // delegated single logic-sig account
+        LogicsigSignature lsigDelegated = new LogicsigSignature(program, args);
+        Account signerAccount = new Account(maKp0);
+        signerAccount.signLogicsig(lsigDelegated);
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LogicSigAccount(lsigDelegated, null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LogicSigAccount(lsigDelegated, new Account(maKp2).getEd25519PublicKey()));
+        LogicSigAccount lsaDelegated = new LogicSigAccount(lsigDelegated, signerAccount.getEd25519PublicKey());
+        assertThat(lsaDelegated.lsig).isEqualTo(lsigDelegated);
+        assertThat(lsaDelegated.sigKey).isEqualTo(signerAccount.getEd25519PublicKey());
+
+        // delegated multi logic-sig account
+        LogicsigSignature lsigMultiDelegated = new LogicsigSignature(program, args);
+        Account signer0 = new Account(maKp0);
+        signer0.signLogicsig(lsigMultiDelegated, ma);
+        Account signer1 = new Account(maKp1);
+        signer1.signLogicsig(lsigMultiDelegated, ma);
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LogicSigAccount(lsigMultiDelegated, new Account(maKp2).getEd25519PublicKey()));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LogicSigAccount(lsigMultiDelegated, new Account(maKp1).getEd25519PublicKey()));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new LogicSigAccount(lsigMultiDelegated, new Account(maKp0).getEd25519PublicKey()));
+        LogicSigAccount lsaMultiDelegated = new LogicSigAccount(lsigMultiDelegated, null);
+        assertThat(lsaMultiDelegated.lsig).isEqualTo(lsigMultiDelegated);
+        assertThat(lsaMultiDelegated.sigKey).isNull();
+    }
+
+    @Test
+    public void testLogicSigAccountAddress() throws GeneralSecurityException, IOException {
+        // escrow logic-sig account
+        LogicSigAccount lsaEscrow = new LogicSigAccount(program, args);
+        Address expectedEscrowAddr = new Address("6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY");
+        assertThat(lsaEscrow.getAddress()).isEqualTo(expectedEscrowAddr);
+
+        // delegated single logic-sig account
+        LogicSigAccount lsaDelegated = new LogicSigAccount(program, args, kp.getPrivate());
+        assertThat(lsaDelegated.getAddress()).isEqualTo(singleDelegateAccount.getAddress());
+
+        // delegated multi logic-sig account'
+        LogicSigAccount lsaMultiDelegated = new LogicSigAccount(program, args, maKp0.getPrivate(), ma);
+        assertThat(lsaMultiDelegated.getAddress()).isEqualTo(ma.toAddress());
     }
 }

--- a/src/test/java/com/algorand/algosdk/account/TestLogicSigAccount.java
+++ b/src/test/java/com/algorand/algosdk/account/TestLogicSigAccount.java
@@ -1,0 +1,20 @@
+package com.algorand.algosdk.account;
+
+import org.junit.jupiter.api.Test;
+
+public class TestLogicSigAccount {
+    @Test
+    public void testLogicSigAccount() {
+
+    }
+
+    @Test
+    public void testLogicSigAccountFromLogicSig() {
+
+    }
+
+    @Test
+    public void testLogicSigAccountAddress() {
+
+    }
+}

--- a/src/test/java/com/algorand/algosdk/account/TestLogicSigAccount.java
+++ b/src/test/java/com/algorand/algosdk/account/TestLogicSigAccount.java
@@ -115,7 +115,7 @@ public class TestLogicSigAccount {
     }
 
     @Test
-    public void testLogicSigAccountFromLogicSig() throws IOException {
+    public void testLogicSigAccountFromLogicSig() throws IOException, NoSuchAlgorithmException {
         // escrow logic-sig account
         LogicsigSignature lsigNoKey = new LogicsigSignature(program, args);
         Assertions.assertThrows(IllegalArgumentException.class, () -> new LogicSigAccount(lsigNoKey, singleDelegateAccount.getEd25519PublicKey()));

--- a/src/test/java/com/algorand/algosdk/account/TestLogicSigAccount.java
+++ b/src/test/java/com/algorand/algosdk/account/TestLogicSigAccount.java
@@ -3,12 +3,16 @@ package com.algorand.algosdk.account;
 import com.algorand.algosdk.crypto.*;
 import com.algorand.algosdk.crypto.Signature;
 import com.algorand.algosdk.mnemonic.Mnemonic;
+import com.algorand.algosdk.transaction.SignedTransaction;
+import com.algorand.algosdk.transaction.Transaction;
+import com.algorand.algosdk.util.Encoder;
 import org.bouncycastle.util.test.FixedSecureRandom;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.security.*;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,6 +23,8 @@ import static org.assertj.core.api.Assertions.*;
 public class TestLogicSigAccount {
     byte[] program;
     ArrayList<byte[]> args;
+    String otherAddrStr, programHash;
+    byte[] note;
     final String SK_MNEMONIC = "olympic cricket tower model share zone grid twist sponsor avoid eight apology patient party success claim famous rapid donor pledge bomb mystery security ability often";
     Account singleDelegateAccount;
     KeyPair kp;
@@ -41,6 +47,9 @@ public class TestLogicSigAccount {
         byte[] arg1 = {0x02, 0x03};
         args.add(arg0);
         args.add(arg1);
+        note = new byte[]{(byte) 180, 81, 121, 57, (byte) 252, (byte) 250, (byte) 210, 113};
+        otherAddrStr = "WTDCE2FEYM2VB5MKNXKLRSRDTSPR2EFTIGVH4GRW4PHGD6747GFJTBGT2A";
+        programHash = "6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY";
 
         byte[] seed = Mnemonic.toKey(SK_MNEMONIC);
         singleDelegateAccount = new Account(seed);
@@ -163,5 +172,95 @@ public class TestLogicSigAccount {
         // delegated multi logic-sig account'
         LogicSigAccount lsaMultiDelegated = new LogicSigAccount(program, args, maKp0.getPrivate(), ma);
         assertThat(lsaMultiDelegated.getAddress()).isEqualTo(ma.toAddress());
+    }
+
+    private void testSign(LogicSigAccount lsa, Address sender, String expectedTxid, Address expectedAuthAddr, byte[] expectedBytes)
+            throws GeneralSecurityException, IOException {
+        Address to = new Address(otherAddrStr);
+
+        BigInteger firstRound = BigInteger.valueOf(972508);
+
+        Transaction tx = Transaction.PaymentTransactionBuilder()
+                .sender(sender)
+                .flatFee(BigInteger.valueOf(217000))
+                .firstValid(firstRound)
+                .lastValid(firstRound.longValue() + 1000)
+                .note(note)
+                .genesisID("testnet-v31.0")
+                .genesisHash(new Digest())
+                .amount(BigInteger.valueOf(5000))
+                .receiver(to)
+                .build();
+
+        SignedTransaction stx = lsa.signLogicSigTransaction(tx);
+        byte[] stxBytes = Encoder.encodeToMsgPack(stx);
+        assertThat(stxBytes).isEqualTo(expectedBytes);
+        assertThat(stx.transactionID).isEqualTo(expectedTxid);
+        assertThat(stx.authAddr).isEqualTo(expectedAuthAddr);
+        assertThat(stx.lSig).isEqualTo(lsa.lsig);
+        assertThat(stx.mSig).isEqualTo(new MultisigSignature());
+        assertThat(stx.sig).isEqualTo(new Signature());
+    }
+
+    @Test
+    public void testNoSigContractAddr() throws GeneralSecurityException, IOException {
+        LogicSigAccount lsaNoSig = new LogicSigAccount(program, args);
+        Address programAddr = new Address(programHash);
+        String expectedTxID = "IL5UCKXGWBA2MQ4YYFQKYC3BFCWO2KHZSNZWVDIXOOZS3AWVIQDA";
+        Address expectedAuthAddr = new Address();
+        String expectedByteEncoded = "QKSGY43JM6BKGYLSM6JMIAIBYQBAEA5BNTCAKAJAAEASFI3UPBXITI3BNV2M2E4IUNTGKZOOAABU7KFCMZ3M4AAO23OKGZ3FN2WXIZLTORXGK5BNOYZTCLRQUJWHNTQAB3NMJJDON52GLRAIWRIXSOP47LJHDI3SMN3MIIFUYYRGRJGDGVIPLCTN2S4MUI44T4ORBM2BVJ7BUNXDZZQ7X7HZRKRXG3TEYQQPM5RNVR23DGL5NQWJMGAGQBIHJEGXSUIS77T7W5QLE44K7HD7DLNEOR4XAZNDOBQXS";
+        byte[] expectedBytes = Encoder.decodeFromBase32StripPad(expectedByteEncoded);
+        testSign(lsaNoSig, programAddr, expectedTxID, expectedAuthAddr, expectedBytes);
+    }
+
+    @Test
+    public void testNoSigNotContractAddr() throws GeneralSecurityException, IOException {
+        LogicSigAccount lsaNoSig = new LogicSigAccount(program, args);
+        Address programAddr = new Address(programHash);
+        String expectedTxID = "U4X24Q45MCZ6JSL343QNR3RC6AJO2NUDQXFCTNONIW3SU2AYQJOA";
+        String expectedByteEncoded = "QOSGY43JM6BKGYLSM6JMIAIBYQBAEA5BNTCAKAJAAEASFJDTM5XHFRBA6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GW2G5DYN2E2GYLNOTGRHCFDMZSWLTQAANH2RITGO3HAADWW3SRWOZLOVV2GK43UNZSXILLWGMYS4MFCNR3M4AAO3LCKI3TPORS4ICFUKF4TT7H22JY2G4TDO3CCBNGGEJUKJQZVKD2YU3OUXDFCHHE7DUILGQNKPYNDNY6OMH57Z6MKUNZW4ZGEEC2MMITIUTBTKUHVRJW5JOGKEOOJ6HIQWNA2U7Q2G3R44YP37T4YVJDUPFYGLI3QMF4Q";
+        byte[] expectedBytes = Encoder.decodeFromBase32StripPad(expectedByteEncoded);
+        testSign(lsaNoSig, new Address(otherAddrStr), expectedTxID, programAddr, expectedBytes);
+    }
+
+    @Test
+    public void testSingleSigContractAddr() throws GeneralSecurityException, IOException {
+        Account acc = new Account(kp.getPrivate());
+        LogicSigAccount lsa = new LogicSigAccount(program, args, kp.getPrivate());
+        String expectedTxID = "XPFTYDOV5RCL7K5EGTC32PSTRKFO3ITZIL64CRTYIJEPHXOTCCXA";
+        String expectedByteEncoded = "QKSGY43JM6B2GYLSM6JMIAIBYQBAEA5BNTCAKAJAAEASFI3TNFT4IQB6AU6TSTP3CK6GK6M75IYYU64OUJIYWVJMRK7GZV5HMUW5RMAYPYQQKLNZERRISFXFMF2M2DYZVS4WYRNEFGIZSEI54R6OJ7AS5THAFI3UPBXITI3BNV2M2E4IUNTGKZOOAABU7KFCMZ3M4AAO23OKGZ3FN2WXIZLTORXGK5BNOYZTCLRQUJWHNTQAB3NMJJDON52GLRAIWRIXSOP47LJHDI3SMN3MIIFUYYRGRJGDGVIPLCTN2S4MUI44T4ORBM2BVJ7BUNXDZZQ7X7HZRKRXG3TEYQQF4Z2PDQFO53BXOGEY6YOHN725ESQZPE7CZEP2BBIWEY7DQVZ6UQVEOR4XAZNDOBQXS";
+        byte[] expectedBytes = Encoder.decodeFromBase32StripPad(expectedByteEncoded);
+        testSign(lsa, acc.getAddress(), expectedTxID, new Address(), expectedBytes);
+    }
+
+    @Test
+    public void testSingleSigNotContractAddr() throws GeneralSecurityException, IOException {
+        Account acc = new Account(kp.getPrivate());
+        LogicSigAccount lsa = new LogicSigAccount(program, args, kp.getPrivate());
+        String expectedTxID = "U4X24Q45MCZ6JSL343QNR3RC6AJO2NUDQXFCTNONIW3SU2AYQJOA";
+        String expectedByteEncoded = "QOSGY43JM6B2GYLSM6JMIAIBYQBAEA5BNTCAKAJAAEASFI3TNFT4IQB6AU6TSTP3CK6GK6M75IYYU64OUJIYWVJMRK7GZV5HMUW5RMAYPYQQKLNZERRISFXFMF2M2DYZVS4WYRNEFGIZSEI54R6OJ7AS5THAFJDTM5XHFRBALZTU6HAK53WDO4MJR5Q4O37V2JFBS6J6FSI7UCCRMJR6HBLT5JBKG5DYN2E2GYLNOTGRHCFDMZSWLTQAANH2RITGO3HAADWW3SRWOZLOVV2GK43UNZSXILLWGMYS4MFCNR3M4AAO3LCKI3TPORS4ICFUKF4TT7H22JY2G4TDO3CCBNGGEJUKJQZVKD2YU3OUXDFCHHE7DUILGQNKPYNDNY6OMH57Z6MKUNZW4ZGEEC2MMITIUTBTKUHVRJW5JOGKEOOJ6HIQWNA2U7Q2G3R44YP37T4YVJDUPFYGLI3QMF4Q";
+        byte[] expectedByte = Encoder.decodeFromBase32StripPad(expectedByteEncoded);
+        Address expectedAuthAddr = acc.getAddress();
+        testSign(lsa, new Address(otherAddrStr), expectedTxID, expectedAuthAddr, expectedByte);
+    }
+
+    @Test
+    public void testMultiSigContractAddr() throws GeneralSecurityException, IOException {
+        LogicSigAccount lsa = new LogicSigAccount(program, args, maKp0.getPrivate(), ma);
+        lsa.appendMultiSig(maKp1.getPrivate());
+        String expectedTxID = "2I2QT3MGXNMB5IOTNWEQZWUJCHLJ5QFBYI264X5NWMUDKZXPZ5RA";
+        String expectedByteEncoded = "QKSGY43JM6B2GYLSM6JMIAIBYQBAEA5BNTCAKAJAAEASFJDNONUWPA5GON2WE43JM6JYFITQNPCCAG36YCYEX2TBW6LJBF7GZP2APYIIU4CTKHILZGFL5MJCBGUKXALYUFZ4IQCJCO4ALUM6P4WBBAHWGN7BQVFHZ3VO4EG5XUJWLBF7SO3V6MDDCWI4UIYM5XXSHULUDNJJ3MH7543VJVSG6S2WD7ELXQWXWTTDLS6QFAVCOBV4IIAJMMZASU3TRHYHKZYRO44ZDR6QHYNXHSGE6UV7NL7QDKRFZ6OCOGQXHRCAMS6FLW7NSGREDVBKWZQPPYKKXGMZUUVTWFYVRTX4H5H6PSZCIEKK3KJ5L2CAKAQKC6TGTAYDEJHINI4LNI3MKVF6EBIP7U7OVCZQICMBUJYGXRBA47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ2G5DIOIBKC5QBUN2HQ3UJUNQW25GNCOEKGZTFMXHAAA2PVCRGM5WOAAHNNXFDM5SW5LLUMVZXI3TFOQWXMMZRFYYKE3DWZYAA5WWEURXG65DFYQELIULZHH6PVUTRUNZGG5WEEC2MMITIUTBTKUHVRJW5JOGKEOOJ6HIQWNA2U7Q2G3R44YP37T4YVI3TNZSMIIENSK2ITEABOOQE36SDLGRWM2TK7TVCYQVALXM4D5Z65OSUPABX5GSHI6LQMWRXAYLZ";
+        byte[] expectedBytes = Encoder.decodeFromBase32StripPad(expectedByteEncoded);
+        testSign(lsa, ma.toAddress(), expectedTxID, new Address(), expectedBytes);
+    }
+
+    @Test
+    public void testMultiSigNotContractAddr() throws GeneralSecurityException, IOException {
+        LogicSigAccount lsa = new LogicSigAccount(program, args, maKp0.getPrivate(), ma);
+        lsa.appendMultiSig(maKp1.getPrivate());
+        String expectedTxID = "U4X24Q45MCZ6JSL343QNR3RC6AJO2NUDQXFCTNONIW3SU2AYQJOA";
+        String expectedByteEncoded = "QOSGY43JM6B2GYLSM6JMIAIBYQBAEA5BNTCAKAJAAEASFJDNONUWPA5GON2WE43JM6JYFITQNPCCAG36YCYEX2TBW6LJBF7GZP2APYIIU4CTKHILZGFL5MJCBGUKXALYUFZ4IQCJCO4ALUM6P4WBBAHWGN7BQVFHZ3VO4EG5XUJWLBF7SO3V6MDDCWI4UIYM5XXSHULUDNJJ3MH7543VJVSG6S2WD7ELXQWXWTTDLS6QFAVCOBV4IIAJMMZASU3TRHYHKZYRO44ZDR6QHYNXHSGE6UV7NL7QDKRFZ6OCOGQXHRCAMS6FLW7NSGREDVBKWZQPPYKKXGMZUUVTWFYVRTX4H5H6PSZCIEKK3KJ5L2CAKAQKC6TGTAYDEJHINI4LNI3MKVF6EBIP7U7OVCZQICMBUJYGXRBA47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ2G5DIOIBKC5QBURZWO3TSYQQI3EVURGIAC45AJX5EGWNDMZVGV7HKFRBKAXOZYH3T525FI6ADP2NDOR4G5CNDMFWXJTITRCRWMZLFZYAAGT5IUJTHNTQAB3LNZI3HMVXK25DFON2G4ZLUFV3DGMJOGCRGY5WOAAHNVRFENZXXIZOEBC2FC6JZ7T5NE4NDOJRXNRBAWTDCE2FEYM2VB5MKNXKLRSRDTSPR2EFTIGVH4GRW4PHGD6747GFKG43OMTCCBNGGEJUKJQZVKD2YU3OUXDFCHHE7DUILGQNKPYNDNY6OMH57Z6MKUR2HS4DFUNYGC6I";
+        byte[] expectedBytes = Encoder.decodeFromBase32StripPad(expectedByteEncoded);
+        testSign(lsa, new Address(otherAddrStr), expectedTxID, ma.toAddress(), expectedBytes);
     }
 }

--- a/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
@@ -60,13 +60,6 @@ public class TestLogicsigSignature {
         outBytes = Encoder.encodeToMsgPack(lsig);
         lsig1 = Encoder.decodeFromMsgPack(outBytes, LogicsigSignature.class);
         assertThat(lsig).isEqualTo(lsig1);
-
-        // check modified program fails on verification
-        program[3] = 2;
-        lsig = new LogicsigSignature(program);
-        verified = lsig.verify(sender);
-        assertThat(verified).isFalse();
-        TestUtil.serializeDeserializeCheck(lsig);
     }
 
     @Test

--- a/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
+++ b/src/test/java/com/algorand/algosdk/crypto/TestLogicsigSignature.java
@@ -169,4 +169,43 @@ public class TestLogicsigSignature {
         assertThat(verified).isTrue();
         TestUtil.serializeDeserializeCheck(lsig2);
     }
+
+    @Test
+    public void testLogicSigAddress() throws Exception {
+        byte[] program = {
+            0x01, 0x20, 0x01, 0x01, 0x22
+        };
+        Address expectedAddress = new Address("6Z3C3LDVWGMX23BMSYMANACQOSINPFIRF77H7N3AWJZYV6OH6GWTJKVMXY");
+
+        // Escrow Logic-sig address compare
+        LogicsigSignature lsig0 = new LogicsigSignature(program);
+        assertThat(lsig0.toAddress()).isEqualTo(expectedAddress);
+
+        Address one = new Address("DN7MBMCL5JQ3PFUQS7TMX5AH4EEKOBJVDUF4TCV6WERATKFLQF4MQUPZTA");
+        Address two = new Address("BFRTECKTOOE7A5LHCF3TTEOH2A7BW46IYT2SX5VP6ANKEXHZYJY77SJTVM");
+        Address three = new Address("47YPQTIGQEO7T4Y4RWDYWEKV6RTR2UNBQXBABEEGM72ESWDQNCQ52OPASU");
+        MultisigAddress ma = new MultisigAddress(
+                1, 2, Arrays.asList(
+                new Ed25519PublicKey(one.getBytes()),
+                new Ed25519PublicKey(two.getBytes()),
+                new Ed25519PublicKey(three.getBytes())
+        )
+        );
+
+        String mn1 = "auction inquiry lava second expand liberty glass involve ginger illness length room item discover ahead table doctor term tackle cement bonus profit right above catch";
+        String mn2 = "since during average anxiety protect cherry club long lawsuit loan expand embark forum theory winter park twenty ball kangaroo cram burst board host ability left";
+        Account acc1 = new Account(mn1);
+        Account acc2 = new Account(mn2);
+
+        // single signed Logic-sig address compare
+        LogicsigSignature lsig1 = new LogicsigSignature(program);
+        acc1.signLogicsig(lsig1);
+        assertThat(lsig1.toAddress()).isEqualTo(expectedAddress);
+
+        // multi-signed Logic-sig address compare
+        LogicsigSignature lsig2 = new LogicsigSignature(program);
+        acc1.signLogicsig(lsig2, ma);
+        acc2.appendToLogicsig(lsig2);
+        assertThat(lsig2.toAddress()).isEqualTo(expectedAddress);
+    }
 }


### PR DESCRIPTION
This is the corresponding implementation and improvement from algorand/go-algorand-sdk#230.

This PR also added method for consttruction `Account` from `PrivateKey` and `KeyPair`, to resolve #245.

Details:
- MultiSig Changes:
  - `Account.signMultisigTransaction` can allow signing from any address.
  - `Account.mergeMultisigTransactions` now checks if multi-sig address and auth-address match.
- LogicSig Changes:
  - Introduced `LogicSigAccount`, which contains a `LogicSig` and (optional) a publicKey that signed it.
  - `LogicSig.verify` now only take address input when it's delegated to an account backed by one privateKey.
  - `Account.signLogicsigTransaction` can sign transaction from any address (take advantage of authAddr), except LogicSig is delegated to non-multisig account and sender is not the delegating account.
    (see algorand/go-algorand-sdk#230 for details)
  - `LogicSigAccount.signLogicSigTransaction` can sign transaction from any address without limitation.
- Minor:
  - `Account` has 2 more constructor, which allows constructing `Account` from `PrivateKey` and `KeyPair`.
  - Introduced a method to extract a `MultiSigAddress` from `MultiSigSignature`.