### PR TITLE
Allow non-base64 metadatahash and force 32 bytes

### DIFF
--- a/src/main/java/com/algorand/algosdk/transaction/AssetParams.java
+++ b/src/main/java/com/algorand/algosdk/transaction/AssetParams.java
@@ -104,8 +104,7 @@ public class AssetParams implements Serializable {
         }
 
         if(metadataHash != null) {
-            if (metadataHash.length > 32) throw new RuntimeException("asset metadataHash cannot be greater than 32 bytes");
-            if (!Base64.isBase64(metadataHash)) throw new RuntimeException("asset metadataHash '" + new String(metadataHash) + "' is not base64 encoded");
+            if (metadataHash.length != 32) throw new RuntimeException("asset metadataHash must have 32 bytes");
             this.metadataHash = metadataHash;
         }
     }


### PR DESCRIPTION
https://github.com/algorand/java-algorand-sdk/pull/74
prevents non-base64 strings to be metadatahash

However, the specs of Algorand allows for metadatahash to be any
array of 32 bytes. This is important to allow to store SHA256 hashes
for example. Indeed, a 32-byte base64 string only represents 24 bytes.

This commit fixes the above and adds tests to check that all the ways
to provide metadata hash (as a UTF8 string, as a base64 string, or
as a byte array) leads to the same transaction.

Furthermore, this commit ensures that metadatahash is exactly 32
bytes, as mandated by the spec.

See
https://github.com/algorandfoundation/specs/blob/master/dev/ledger.md#assets
and
https://github.com/algorand/go-algorand/blob/96b16ff090014e520a4695285d4167d26c5468ad/data/basics/userBalance.go#L364