### PR TITLE
Better error message on encoding exception.

### DIFF
--- a/src/main/java/com/algorand/algosdk/v2/client/common/Response.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/common/Response.java
@@ -72,7 +72,12 @@ public class Response<T> {
         } catch (Exception e) {
             // Check if the data was base64 encoded.
             byte[] bytes = Encoder.decodeFromBase64(new String(body));
-            return Utils.msgpReader.forType(valueType).readValue(bytes);
+            try {
+                return Utils.msgpReader.forType(valueType).readValue(bytes);
+            } catch (Exception e2) {
+                // Significantly more likely to have a useful error in the original exception.
+                throw e;
+            }
         }
     }
 


### PR DESCRIPTION
The encoding code attempts to b64 decode the message pack data as a fallback. This usually wont help, so return the first exception if b64 decoding doesn't help.