### PR TITLE
Implementation for ABI spec change

### DIFF
--- a/src/main/java/com/algorand/algosdk/abi/Contract.java
+++ b/src/main/java/com/algorand/algosdk/abi/Contract.java
@@ -49,7 +49,12 @@ public class Contract {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Contract contract = (Contract) o;
-        return Objects.equals(name, contract.name) && Objects.equals(networks, contract.networks) && Objects.equals(methods, contract.methods);
+        if (!contract.networks.keySet().equals(this.networks.keySet())) return false;
+        for (String networkHash : this.networks.keySet()) {
+            if (!contract.getAppIDbyHash(networkHash).equals(this.getAppIDbyHash(networkHash)))
+                return false;
+        }
+        return Objects.equals(name, contract.name) && Objects.equals(methods, contract.methods);
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -60,6 +65,13 @@ public class Contract {
         @JsonCreator
         public AppID(@JsonProperty("appID") Integer appID) {
             this.appID = Objects.requireNonNull(appID, "appID must not be null");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || o.getClass() != getClass()) return false;
+            AppID otherAppID = (AppID) o;
+            return Objects.equals(appID, otherAppID.appID);
         }
     }
 }

--- a/src/main/java/com/algorand/algosdk/abi/Contract.java
+++ b/src/main/java/com/algorand/algosdk/abi/Contract.java
@@ -7,25 +7,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Contract {
     @JsonProperty("name")
     public String name;
-    @JsonProperty("appId")
-    public Integer appId;
+    @JsonProperty("networks")
+    public Map<String, AppID> networks;
     @JsonProperty("methods")
     public List<Method> methods = new ArrayList<>();
 
     @JsonCreator
     public Contract(
             @JsonProperty("name") String name,
-            @JsonProperty("appId") Integer appId,
+            @JsonProperty("networks") Map<String, AppID> networks,
             @JsonProperty("methods") List<Method> methods
     ) {
         this.name = Objects.requireNonNull(name, "name must not be null");
-        this.appId = Objects.requireNonNull(appId, "name must not be null");
+        this.networks = networks;
         if (methods != null) this.methods = methods;
     }
 
@@ -35,8 +36,8 @@ public class Contract {
     }
 
     @JsonIgnore
-    public Integer getAppId() {
-        return this.appId;
+    public Integer getAppIDbyHash(String genesisHash) {
+        return this.networks.get(genesisHash).appID;
     }
 
     @JsonIgnore
@@ -48,6 +49,17 @@ public class Contract {
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
         Contract contract = (Contract) o;
-        return Objects.equals(name, contract.name) && Objects.equals(appId, contract.appId) && Objects.equals(methods, contract.methods);
+        return Objects.equals(name, contract.name) && Objects.equals(networks, contract.networks) && Objects.equals(methods, contract.methods);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    static public class AppID {
+        @JsonProperty("appID")
+        public Integer appID;
+
+        @JsonCreator
+        public AppID(@JsonProperty("appID") Integer appID) {
+            this.appID = Objects.requireNonNull(appID, "appID must not be null");
+        }
     }
 }

--- a/src/main/java/com/algorand/algosdk/transaction/AtomicTransactionComposer.java
+++ b/src/main/java/com/algorand/algosdk/transaction/AtomicTransactionComposer.java
@@ -182,11 +182,12 @@ public class AtomicTransactionComposer {
 
         if (this.transactionList.size() == 0)
             throw new IllegalArgumentException("should not build transaction group with 0 transaction in composer");
-
-        List<Transaction> groupTxns = new ArrayList<>();
-        for (TransactionWithSigner t : this.transactionList) groupTxns.add(t.txn);
-        Digest groupID = TxGroup.computeGroupID(groupTxns.toArray(new Transaction[0]));
-        for (TransactionWithSigner tws : this.transactionList) tws.txn.group = groupID;
+        else if (this.transactionList.size() > 1) {
+            List<Transaction> groupTxns = new ArrayList<>();
+            for (TransactionWithSigner t : this.transactionList) groupTxns.add(t.txn);
+            Digest groupID = TxGroup.computeGroupID(groupTxns.toArray(new Transaction[0]));
+            for (TransactionWithSigner tws : this.transactionList) tws.txn.group = groupID;
+        }
 
         this.status = Status.BUILT;
         return this.transactionList;

--- a/src/main/java/com/algorand/algosdk/transaction/AtomicTransactionComposer.java
+++ b/src/main/java/com/algorand/algosdk/transaction/AtomicTransactionComposer.java
@@ -28,6 +28,8 @@ public class AtomicTransactionComposer {
     }
 
     public static final int MAX_GROUP_SIZE = 16;
+    // if the abi type argument number > 15, then the abi types after 14th should be wrapped in a tuple
+    private static final int MAX_ABI_ARG_TYPE_LEN = 15;
 
     private static final byte[] ABI_RET_HASH = new byte[]{0x15, 0x1f, 0x7c, 0x75};
 
@@ -126,20 +128,20 @@ public class AtomicTransactionComposer {
                 );
         }
 
-        if (methodArgs.size() > 14) {
-            List<ABIType> wrappedABITypes = new ArrayList<>();
-            List<Object> wrappedValues = new ArrayList<>();
+        if (methodArgs.size() > MAX_ABI_ARG_TYPE_LEN) {
+            List<ABIType> wrappedABITypeList = new ArrayList<>();
+            List<Object> wrappedValueList = new ArrayList<>();
 
-            for (int i = 14; i < methodArgs.size(); i++) {
-                wrappedABITypes.add(methodABIts.get(i));
-                wrappedValues.add(methodArgs.get(i));
+            for (int i = MAX_ABI_ARG_TYPE_LEN - 1; i < methodArgs.size(); i++) {
+                wrappedABITypeList.add(methodABIts.get(i));
+                wrappedValueList.add(methodArgs.get(i));
             }
 
-            TypeTuple tupleT = new TypeTuple(wrappedABITypes);
-            methodABIts = methodABIts.subList(0, 14);
+            TypeTuple tupleT = new TypeTuple(wrappedABITypeList);
+            methodABIts = methodABIts.subList(0, MAX_ABI_ARG_TYPE_LEN - 1);
             methodABIts.add(tupleT);
-            methodArgs = methodArgs.subList(0, 14);
-            methodArgs.add(wrappedValues);
+            methodArgs = methodArgs.subList(0, MAX_ABI_ARG_TYPE_LEN - 1);
+            methodArgs.add(wrappedValueList);
         }
 
         for (int i = 0; i < methodArgs.size(); i++)

--- a/src/test/java/com/algorand/algosdk/abi/TestContract.java
+++ b/src/test/java/com/algorand/algosdk/abi/TestContract.java
@@ -35,7 +35,7 @@ public class TestContract {
 
     @Test
     public void TestContractClassMethods() throws IOException {
-        String testJSON = "{\"name\": \"Calculator\", \"networks\": {\"wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=\": {\"appId\": 10}}, \"methods\": [{ \"name\": \"add\", \"args\": [ { \"name\": \"a\", \"type\": \"uint64\", \"desc\": \"...\" },{ \"name\": \"b\", \"type\": \"uint64\", \"desc\": \"...\" } ] },{ \"name\": \"multiply\", \"args\": [ { \"name\": \"a\", \"type\": \"uint64\", \"desc\": \"...\" },{ \"name\": \"b\", \"type\": \"uint64\", \"desc\": \"...\" } ] }]}";
+        String testJSON = "{\"name\": \"Calculator\", \"networks\": {\"wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=\": {\"appID\": 10}}, \"methods\": [{ \"name\": \"add\", \"args\": [ { \"name\": \"a\", \"type\": \"uint64\", \"desc\": \"...\" },{ \"name\": \"b\", \"type\": \"uint64\", \"desc\": \"...\" } ] },{ \"name\": \"multiply\", \"args\": [ { \"name\": \"a\", \"type\": \"uint64\", \"desc\": \"...\" },{ \"name\": \"b\", \"type\": \"uint64\", \"desc\": \"...\" } ] }]}";
         Contract readContract = objMapper.readValue(testJSON.getBytes(StandardCharsets.UTF_8), Contract.class);
         assertThat(readContract).isEqualTo(new Contract("Calculator", Collections.singletonMap("wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=", new Contract.AppID(10)), methodList));
         assertThat(readContract.getAppIDbyHash("wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=")).isEqualTo(10);

--- a/src/test/java/com/algorand/algosdk/abi/TestContract.java
+++ b/src/test/java/com/algorand/algosdk/abi/TestContract.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,10 +35,10 @@ public class TestContract {
 
     @Test
     public void TestContractClassMethods() throws IOException {
-        String testJSON = "{\"name\": \"Calculator\",\"appId\": 10, \"methods\": [{ \"name\": \"add\", \"args\": [ { \"name\": \"a\", \"type\": \"uint64\", \"desc\": \"...\" },{ \"name\": \"b\", \"type\": \"uint64\", \"desc\": \"...\" } ] },{ \"name\": \"multiply\", \"args\": [ { \"name\": \"a\", \"type\": \"uint64\", \"desc\": \"...\" },{ \"name\": \"b\", \"type\": \"uint64\", \"desc\": \"...\" } ] }]}";
+        String testJSON = "{\"name\": \"Calculator\", \"networks\": {\"wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=\": {\"appId\": 10}}, \"methods\": [{ \"name\": \"add\", \"args\": [ { \"name\": \"a\", \"type\": \"uint64\", \"desc\": \"...\" },{ \"name\": \"b\", \"type\": \"uint64\", \"desc\": \"...\" } ] },{ \"name\": \"multiply\", \"args\": [ { \"name\": \"a\", \"type\": \"uint64\", \"desc\": \"...\" },{ \"name\": \"b\", \"type\": \"uint64\", \"desc\": \"...\" } ] }]}";
         Contract readContract = objMapper.readValue(testJSON.getBytes(StandardCharsets.UTF_8), Contract.class);
-        assertThat(readContract).isEqualTo(new Contract("Calculator", 10, methodList));
-        assertThat(readContract.getAppId()).isEqualTo(10);
+        assertThat(readContract).isEqualTo(new Contract("Calculator", Collections.singletonMap("wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=", new Contract.AppID(10)), methodList));
+        assertThat(readContract.getAppIDbyHash("wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=")).isEqualTo(10);
         assertThat(readContract.getName()).isEqualTo("Calculator");
         for (int i = 0; i < readContract.methods.size(); i++)
             assertThat(readContract.getMethodByIndex(i)).isEqualTo(methodList.get(i));

--- a/src/test/java/com/algorand/algosdk/unit/ABIJson.java
+++ b/src/test/java/com/algorand/algosdk/unit/ABIJson.java
@@ -86,7 +86,7 @@ public class ABIJson {
 
     @When("I create a Contract object from the Method object with name {string} and appId {int}")
     public void i_create_a_contract_object_from_the_method_object_with_name_and_app_id(String string, Integer int1) {
-        this.contract = new Contract(string, int1, Collections.singletonList(this.method));
+        this.contract = new Contract(string, Collections.singletonMap("", new Contract.AppID(int1)), Collections.singletonList(this.method));
         this.state = CHECK_FIELD.CONTRACT;
     }
 

--- a/src/test/java/com/algorand/algosdk/unit/ABIJson.java
+++ b/src/test/java/com/algorand/algosdk/unit/ABIJson.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 
 public class ABIJson {
     private enum CHECK_FIELD {
@@ -84,10 +85,16 @@ public class ABIJson {
         this.jsonInterface = new ObjectMapper().writeValueAsString(this.interfaceObj);
     }
 
-    @When("I create a Contract object from the Method object with name {string} and appId {int}")
-    public void i_create_a_contract_object_from_the_method_object_with_name_and_app_id(String string, Integer int1) {
-        this.contract = new Contract(string, Collections.singletonMap("", new Contract.AppID(int1)), Collections.singletonList(this.method));
+    @When("I create a Contract object from the Method object with name {string}")
+    public void i_create_a_contract_object_from_the_method_object_with_name_and_app_id(String string) {
+        this.contract = new Contract(string, null, Collections.singletonList(this.method));
+        this.contract.networks = new HashMap<>();
         this.state = CHECK_FIELD.CONTRACT;
+    }
+
+    @When("I set the Contract's appID to <network1-app-id> for the network <network1>")
+    public void i_set_the_contracts_appid_to(Integer appID, String network) {
+        this.contract.networks.put(network, new Contract.AppID(appID));
     }
 
     @When("I serialize the Contract object into json")


### PR DESCRIPTION
## Tasks

- [x] Remove the `appId` field in favor of a new `networks` field in `Contract`.
  - [x] Waiting on cucumber test change, `Contract` construction is somewhat different.
- [x] If a method has exactly 15 arguments, the last argument is no longer required to be encoded in a tuple.
- [x] Clarify that in the case of multiple logged values with the special 4-byte return prefix, the last one is the return value.
- [x] The atomic transaction composer should not add a group ID if there's only 1 transaction in the group.
- [ ] The atomic transaction composer should check that the type of a transaction argument (e.g. pay, axfer, etc.) matches the ABI transaction argument type.

Closes #282.