### PR TITLE
add error message with atomic transaction composer

### DIFF
--- a/src/main/java/com/algorand/algosdk/transaction/AtomicTransactionComposer.java
+++ b/src/main/java/com/algorand/algosdk/transaction/AtomicTransactionComposer.java
@@ -371,7 +371,7 @@ public class AtomicTransactionComposer {
         Response<PostTransactionsResponse> rPost = client.RawTransaction().rawtxn(encoded).execute();
 
         if (!rPost.isSuccessful())
-            throw new Exception("transaction should be submitted successfully");
+            throw new Exception("transaction should be submitted successfully cause : " + rPost.message());
 
         this.status = Status.SUBMITTED;
         return this.getTxIDs();


### PR DESCRIPTION
Add specific error message obtained by rPost transaction when It tried to submit an atomic transaction composer and It failed