### PR TITLE
Added support for SHA256 TxnRoot header

### DIFF
--- a/src/main/java/com/algorand/algosdk/v2/client/algod/GetProof.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/algod/GetProof.java
@@ -5,6 +5,7 @@ import com.algorand.algosdk.v2.client.common.HttpMethod;
 import com.algorand.algosdk.v2.client.common.Query;
 import com.algorand.algosdk.v2.client.common.QueryData;
 import com.algorand.algosdk.v2.client.common.Response;
+import com.algorand.algosdk.v2.client.model.Enums;
 import com.algorand.algosdk.v2.client.model.ProofResponse;
 
 
@@ -26,6 +27,16 @@ public class GetProof extends Query {
         addQuery("format", "msgpack");
         this.round = round;
         this.txid = txid;
+    }
+
+    /**
+     * The type of hash function used to create the proof, must be one of:
+     *   sha512_256
+     *   sha256
+     */
+    public GetProof hashtype(Enums.Hashtype hashtype) {
+        addQuery("hashtype", String.valueOf(hashtype));
+        return this;
     }
 
    /**

--- a/src/main/java/com/algorand/algosdk/v2/client/model/Enums.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/model/Enums.java
@@ -131,11 +131,12 @@ public class Enums {
     }
 
     /**
-     * Combine with the address parameter to define what type of address to search for.
+     * Indicates the type of hash function used.
+     * A query parameter for GetProof, as two types of merkle TxnRoot block headers exists now.
      */
     public enum Hashtype {
-        @JsonProperty("sumhash") SUMHASH("sumhash"),
-        @JsonProperty("sha512_256") SHA512_256("sha512_256");
+        @JsonProperty("sha512_256") SHA512_256("sha512_256"),
+        @JsonProperty("sha256") SHA256("sha256");
 
         final String serializedName;
         Hashtype(String name) {

--- a/src/main/java/com/algorand/algosdk/v2/client/model/ProofResponse.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/model/ProofResponse.java
@@ -12,14 +12,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ProofResponse extends PathResponse {
 
     /**
-     * The type of hash function used to create the proof, must be one of:
-     *   sumhash
-     *   sha512_256
-     */
-    @JsonProperty("hashtype")
-    public Enums.Hashtype hashtype;
-
-    /**
      * Index of the transaction in the block's payset.
      */
     @JsonProperty("idx")
@@ -63,7 +55,6 @@ public class ProofResponse extends PathResponse {
         if (o == null) return false;
 
         ProofResponse other = (ProofResponse) o;
-        if (!Objects.deepEquals(this.hashtype, other.hashtype)) return false;
         if (!Objects.deepEquals(this.idx, other.idx)) return false;
         if (!Objects.deepEquals(this.proof, other.proof)) return false;
         if (!Objects.deepEquals(this.stibhash, other.stibhash)) return false;

--- a/src/main/java/com/algorand/algosdk/v2/client/model/ProofResponse.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/model/ProofResponse.java
@@ -12,6 +12,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ProofResponse extends PathResponse {
 
     /**
+     * The type of hash function used to create the proof, must be one of:
+     *   sha512_256
+     *   sha256
+     */
+    @JsonProperty("hashtype")
+    public Enums.Hashtype hashtype;
+
+    /**
      * Index of the transaction in the block's payset.
      */
     @JsonProperty("idx")
@@ -55,6 +63,7 @@ public class ProofResponse extends PathResponse {
         if (o == null) return false;
 
         ProofResponse other = (ProofResponse) o;
+        if (!Objects.deepEquals(this.hashtype, other.hashtype)) return false;
         if (!Objects.deepEquals(this.idx, other.idx)) return false;
         if (!Objects.deepEquals(this.proof, other.proof)) return false;
         if (!Objects.deepEquals(this.stibhash, other.stibhash)) return false;


### PR DESCRIPTION
HashType enum was updated manually as it was not generated from the OpenAPI (due to the indexer oas2 spec file).