### PR TITLE
Delegate MethodCallParams.Builder to MethodCallTransactionBuilder

### DIFF
--- a/src/main/java/com/algorand/algosdk/builder/transaction/MethodCallTransactionBuilder.java
+++ b/src/main/java/com/algorand/algosdk/builder/transaction/MethodCallTransactionBuilder.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-@SuppressWarnings("unchecked")
 public class MethodCallTransactionBuilder extends TransactionParametersBuilder<MethodCallTransactionBuilder> implements StateSchemaSetter<MethodCallTransactionBuilder>, TEALProgramSetter<MethodCallTransactionBuilder>, ApplicationCallReferencesSetter<MethodCallTransactionBuilder> {
     protected Long appID;
     protected Transaction.OnCompletion onCompletion;

--- a/src/main/java/com/algorand/algosdk/builder/transaction/MethodCallTransactionBuilder.java
+++ b/src/main/java/com/algorand/algosdk/builder/transaction/MethodCallTransactionBuilder.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 
 @SuppressWarnings("unchecked")
-public class MethodCallTransactionBuilder<T extends MethodCallTransactionBuilder<T>> extends TransactionParametersBuilder<T> implements StateSchemaSetter<T>, TEALProgramSetter<T>, ApplicationCallReferencesSetter<T> {
+public class MethodCallTransactionBuilder extends TransactionParametersBuilder<MethodCallTransactionBuilder> implements StateSchemaSetter<MethodCallTransactionBuilder>, TEALProgramSetter<MethodCallTransactionBuilder>, ApplicationCallReferencesSetter<MethodCallTransactionBuilder> {
     protected Long appID;
     protected Transaction.OnCompletion onCompletion;
     protected Method method;
@@ -33,31 +33,31 @@ public class MethodCallTransactionBuilder<T extends MethodCallTransactionBuilder
     /**
      * Initialize a {@link MethodCallTransactionBuilder}.
      */
-    public static MethodCallTransactionBuilder<?> Builder() {
-        return new MethodCallTransactionBuilder<>();
+    public static MethodCallTransactionBuilder Builder() {
+        return new MethodCallTransactionBuilder();
     }
 
     @Override
-    public T applicationId(Long applicationId) {
+    public MethodCallTransactionBuilder applicationId(Long applicationId) {
         this.appID = applicationId;
-        return (T) this;
+        return this;
     }
 
     /**
      * This is the faux application type used to distinguish different application actions. Specifically, OnCompletion
      * specifies what side effects this transaction will have if it successfully makes it into a block.
      */
-    public T onComplete(Transaction.OnCompletion op) {
+    public MethodCallTransactionBuilder onComplete(Transaction.OnCompletion op) {
         this.onCompletion = op;
-        return (T) this;
+        return this;
     }
 
     /**
      * Specify the ABI method that this method call transaction will invoke.
      */
-    public T method(Method method) {
+    public MethodCallTransactionBuilder method(Method method) {
         this.method = method;
-        return (T) this;
+        return this;
     }
 
     /**
@@ -65,9 +65,9 @@ public class MethodCallTransactionBuilder<T extends MethodCallTransactionBuilder
      * 
      * This will reset the arguments list to what is passed in by the caller.
      */
-    public T methodArguments(List<Object> arguments) {
+    public MethodCallTransactionBuilder methodArguments(List<Object> arguments) {
         this.methodArgs = new ArrayList<>(arguments);
-        return (T) this;
+        return this;
     }
 
     /**
@@ -75,9 +75,9 @@ public class MethodCallTransactionBuilder<T extends MethodCallTransactionBuilder
      * 
      * This will add the arguments passed in by the caller to the existing list of arguments.
      */
-    public T addMethodArguments(List<Object> arguments) {
+    public MethodCallTransactionBuilder addMethodArguments(List<Object> arguments) {
         this.methodArgs.addAll(arguments);
-        return (T) this;
+        return this;
     }
 
     /**
@@ -85,77 +85,77 @@ public class MethodCallTransactionBuilder<T extends MethodCallTransactionBuilder
      * 
      * This will add the argument passed in by the caller to the existing list of arguments.
      */
-    public T addMethodArgument(Object argument) {
+    public MethodCallTransactionBuilder addMethodArgument(Object argument) {
         this.methodArgs.add(argument);
-        return (T) this;
+        return this;
     }
 
     /**
      * Specify the signer for this method call transaction.
      */
-    public T signer(TxnSigner signer) {
+    public MethodCallTransactionBuilder signer(TxnSigner signer) {
         this.signer = signer;
-        return (T) this;
+        return this;
     }
 
     @Override
-    public T accounts(List<Address> accounts) {
+    public MethodCallTransactionBuilder accounts(List<Address> accounts) {
         if (accounts != null)
             this.foreignAccounts = new ArrayList<>(new HashSet<>(accounts));
         else
             this.foreignAccounts.clear();
-        return (T) this;
+        return this;
     }
 
     @Override
-    public T foreignApps(List<Long> foreignApps) {
+    public MethodCallTransactionBuilder foreignApps(List<Long> foreignApps) {
         if (foreignApps != null)
             this.foreignApps = new ArrayList<>(new HashSet<>(foreignApps));
         else
             this.foreignApps.clear();
-        return (T) this;
+        return this;
     }
 
     @Override
-    public T foreignAssets(List<Long> foreignAssets) {
+    public MethodCallTransactionBuilder foreignAssets(List<Long> foreignAssets) {
         if (foreignAssets != null)
             this.foreignAssets = new ArrayList<>(new HashSet<>(foreignAssets));
         else
             this.foreignAssets.clear();
-        return (T) this;
+        return this;
     }
 
     @Override
-    public T approvalProgram(TEALProgram approvalProgram) {
+    public MethodCallTransactionBuilder approvalProgram(TEALProgram approvalProgram) {
         this.approvalProgram = approvalProgram;
-        return (T) this;
+        return this;
     }
 
     @Override
-    public T clearStateProgram(TEALProgram clearStateProgram) {
+    public MethodCallTransactionBuilder clearStateProgram(TEALProgram clearStateProgram) {
         this.clearStateProgram = clearStateProgram;
-        return (T) this;
+        return this;
     }
 
     @Override
-    public T localStateSchema(StateSchema localStateSchema) {
+    public MethodCallTransactionBuilder localStateSchema(StateSchema localStateSchema) {
         this.localStateSchema = localStateSchema;
-        return (T) this;
+        return this;
     }
 
     @Override
-    public T globalStateSchema(StateSchema globalStateSchema) {
+    public MethodCallTransactionBuilder globalStateSchema(StateSchema globalStateSchema) {
         this.globalStateSchema = globalStateSchema;
-        return (T) this;
+        return this;
     }
 
     @Override
-    public T extraPages(Long extraPages) {
+    public MethodCallTransactionBuilder extraPages(Long extraPages) {
         if (extraPages == null || extraPages < 0 || extraPages > 3) {
             throw new IllegalArgumentException("extraPages must be an integer between 0 and 3 inclusive");
         }
         this.extraPages = extraPages;
-        return (T) this;
+        return this;
     }
 
     /**

--- a/src/main/java/com/algorand/algosdk/transaction/MethodCallParams.java
+++ b/src/main/java/com/algorand/algosdk/transaction/MethodCallParams.java
@@ -9,7 +9,6 @@ import com.algorand.algosdk.crypto.TEALProgram;
 import com.algorand.algosdk.logic.StateSchema;
 import com.algorand.algosdk.v2.client.model.TransactionParametersResponse;
 
-import javax.swing.plaf.nimbus.State;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/algorand/algosdk/transaction/MethodCallParams.java
+++ b/src/main/java/com/algorand/algosdk/transaction/MethodCallParams.java
@@ -9,6 +9,7 @@ import com.algorand.algosdk.crypto.TEALProgram;
 import com.algorand.algosdk.logic.StateSchema;
 import com.algorand.algosdk.v2.client.model.TransactionParametersResponse;
 
+import javax.swing.plaf.nimbus.State;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -110,122 +111,144 @@ public class MethodCallParams {
      * Deprecated, use {@link com.algorand.algosdk.builder.transaction.MethodCallTransactionBuilder#Builder()} instead.
      */
     @Deprecated
-    public static class Builder extends MethodCallTransactionBuilder<Builder> {
+    public static class Builder {
+
+        private final MethodCallTransactionBuilder delegated = MethodCallTransactionBuilder.Builder();
+        private StateSchema localSchema = new StateSchema();
+        private StateSchema globalSchema = new StateSchema();
+
+        public Builder() {}
 
         public Builder setAppID(Long appID) {
-            return this.applicationId(appID);
+            delegated.applicationId(appID);
+            return this;
         }
 
         public Builder setMethod(Method method) {
-            return this.method(method);
+            delegated.method(method);
+            return this;
         }
 
         public Builder addMethodArgs(Object ma) {
-            return this.addMethodArgument(ma);
+            delegated.addMethodArgument(ma);
+            return this;
         }
 
         public Builder setSender(String sender) {
-            return this.sender(sender);
+            delegated.sender(sender);
+            return this;
         }
 
         public Builder setSuggestedParams(TransactionParams sp) {
-            return this.suggestedParams(sp);
+            delegated.suggestedParams(sp);
+            return this;
         }
 
         public Builder setSuggestedParams(TransactionParametersResponse sp) {
-            return this.suggestedParams(sp);
+            delegated.suggestedParams(sp);
+            return this;
         }
 
         public Builder setOnComplete(Transaction.OnCompletion op) {
-            return this.onComplete(op);
+            delegated.onComplete(op);
+            return this;
         }
 
         public Builder setNote(byte[] note) {
-            return this.note(note);
+            delegated.note(note);
+            return this;
         }
 
         public Builder setLease(byte[] lease) {
-            return this.lease(lease);
+            delegated.lease(lease);
+            return this;
         }
 
         public Builder setRekeyTo(String rekeyTo) {
-            return this.rekey(rekeyTo);
+            delegated.rekey(rekeyTo);
+            return this;
         }
 
         public Builder setSigner(TxnSigner signer) {
-            return this.signer(signer);
+            delegated.signer(signer);
+            return this;
         }
 
         public Builder setFirstValid(BigInteger fv) {
-            return this.firstValid(fv);
+            delegated.firstValid(fv);
+            return this;
         }
 
         public Builder setLastValid(BigInteger lv) {
-            return this.lastValid(lv);
+            delegated.lastValid(lv);
+            return this;
         }
 
         public Builder setFee(BigInteger fee) {
-            return this.fee(fee);
+            delegated.fee(fee);
+            return this;
         }
 
         public Builder setFlatFee(BigInteger flatFee) {
-            return this.flatFee(flatFee);
+            delegated.flatFee(flatFee);
+            return this;
         }
 
         public Builder setForeignAccounts(List<Address> fAccounts) {
-            return this.accounts(fAccounts);
+            delegated.accounts(fAccounts);
+            return this;
         }
 
         public Builder setForeignAssets(List<Long> fAssets) {
-            return this.foreignAssets(fAssets);
+            delegated.foreignAssets(fAssets);
+            return this;
         }
 
         public Builder setForeignApps(List<Long> fApps) {
-            return this.foreignApps(fApps);
+            delegated.foreignApps(fApps);
+            return this;
         }
 
         public Builder setApprovalProgram(TEALProgram approvalProgram) {
-            return this.approvalProgram(approvalProgram);
+            delegated.approvalProgram(approvalProgram);
+            return this;
         }
 
         public Builder setClearProgram(TEALProgram clearProgram) {
-            return this.clearStateProgram(clearProgram);
+            delegated.clearStateProgram(clearProgram);
+            return this;
         }
 
         public Builder setGlobalInts(Long globalInts) {
-            if (this.globalStateSchema == null) {
-                return this.globalStateSchema(new StateSchema(globalInts, 0L));
-            }
-            this.globalStateSchema.numUint = BigInteger.valueOf(globalInts);
+            this.globalSchema.numUint = BigInteger.valueOf(globalInts);
             return this;
         }
 
         public Builder setGlobalBytes(Long globalBytes) {
-            if (this.globalStateSchema == null) {
-                return this.globalStateSchema(new StateSchema(0L, globalBytes));
-            }
-            this.globalStateSchema.numByteSlice = BigInteger.valueOf(globalBytes);
+            this.globalSchema.numByteSlice = BigInteger.valueOf(globalBytes);
             return this;
         }
 
         public Builder setLocalInts(Long localInts) {
-            if (this.localStateSchema == null) {
-                return this.localStateSchema(new StateSchema(localInts, 0L));
-            }
-            this.localStateSchema.numUint = BigInteger.valueOf(localInts);
+            this.localSchema.numUint = BigInteger.valueOf(localInts);
             return this;
         }
 
         public Builder setLocalBytes(Long localBytes) {
-            if (this.localStateSchema == null) {
-                return this.localStateSchema(new StateSchema(0L, localBytes));
-            }
-            this.localStateSchema.numByteSlice = BigInteger.valueOf(localBytes);
+            this.localSchema.numByteSlice = BigInteger.valueOf(localBytes);
             return this;
         }
 
         public Builder setExtraPages(Long extraPages) {
-            return this.extraPages(extraPages);
+            delegated.extraPages(extraPages);
+            return this;
+        }
+
+        public MethodCallParams build() {
+            delegated.localStateSchema(this.localSchema);
+            delegated.globalStateSchema(this.globalSchema);
+
+            return delegated.build();
         }
     }
 }

--- a/src/test/java/com/algorand/algosdk/integration/AtomicTxnComposer.java
+++ b/src/test/java/com/algorand/algosdk/integration/AtomicTxnComposer.java
@@ -38,7 +38,7 @@ public class AtomicTxnComposer {
     TxnSigner transSigner;
     TransactionWithSigner transWithSigner;
     Method method;
-    MethodCallTransactionBuilder<?> optionBuilder;
+    MethodCallTransactionBuilder optionBuilder;
     AtomicTransactionComposer.ExecuteResult execRes;
     SplitAndProcessMethodArgs abiArgProcessor;
     Long appID;

--- a/src/test/java/com/algorand/algosdk/unit/AtomicTxnComposer.java
+++ b/src/test/java/com/algorand/algosdk/unit/AtomicTxnComposer.java
@@ -37,7 +37,7 @@ public class AtomicTxnComposer {
     List<SignedTransaction> signedTxnsGathered;
 
     TransactionWithSigner txnWithSigner;
-    MethodCallTransactionBuilder<?> optionBuilder;
+    MethodCallTransactionBuilder optionBuilder;
     SplitAndProcessMethodArgs abiArgProcessor = null;
 
     public AtomicTxnComposer(Base b, ABIJson methodABI_, TransactionSteps steps) {


### PR DESCRIPTION
Optionally proposes favoring composition over inheritance when adapting `MethodCallParams.Builder` to `MethodCallTransactionBuilder`.

The approach removes one level of generics definition.  Users of `MethodCallTransactionBuilder` no longer need to parameterize types.  From what I understood, there is no further specialization needed because `MethodCallTransactionBuilder` is a non-abstract class.

If I've misunderstood the intent or if we feel it's _not_ a net improvement, then feel welcomed to close the PR.