### PR TITLE
Build: Add SDK code generation workflow

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,19 @@
+name: "SDK Code Generation"
+on:
+  schedule:
+    - cron: '20 23 * * *'
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  generate_and_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Generate and PR
+        uses: algorand/generator/.github/actions/sdk-codegen/
+        with:
+          args: "-k JAVA"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a github workflow which will call our code gen action.  
Depends on action being defined in  our generator... See https://github.com/algorand/generator/pull/32 for more details and testing done.

Runs on a cron job daily at 23:20. The Github docs say to try to avoid common times because there will be natural spikes of event processing happening then, so I've defined all of the jobs at an arbitrary time during the night.

It will run the code generator, commit to a branch if necessary, and open a PR for us to review. It will no-op if the branch w/ identical changes already exist.