### PR TITLE
Add branch info to sdk gen action

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Generate and PR
-        uses: algorand/generator/.github/actions/sdk-codegen/
+        uses: algorand/generator/.github/actions/sdk-codegen/@master
         with:
           args: "-k JAVA"
         env:


### PR DESCRIPTION
Github is complaining that I've left out the "version" which is supposed to be the branch we are referencing a remote action from. Added that in their builtin editor and it seems to be happy with the workflow definition now.