### PR TITLE
Run non-Cucumber unit tests during make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 unit:
+	mvn test
 	mvn test -Dcucumber.filter.tags="@unit.offline or @unit.algod or @unit.indexer or @unit.rekey or @unit.indexer.rekey or @unit.transactions or @unit.transactions.keyreg or @unit.responses or @unit.applications or @unit.dryrun or @unit.tealsign or @unit.responses.messagepack or @unit.responses.231 or @unit.responses.messagepack.231 or @unit.feetest or @unit.indexer.logs or @unit.abijson or @unit.abijson.byname or @unit.atomic_transaction_composer or @unit.transactions.payment or @unit.responses.unlimited_assets or @unit.algod.ledger_refactoring or @unit.indexer.ledger_refactoring or @unit.dryrun.trace.application"
 
 integration:


### PR DESCRIPTION
Modifies `make test` to include non-Cucumber unit tests.

I'm unfamiliar with the history to gauge _why_ non-Cucumber unit tests are _not_ run during local test cycles.  I see the CI build _does_ run non-Cucumber unit tests.  In a future PR, I envision unifying local + CI builds.