### PR TITLE
Ignore copied over txt test resource files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ src/test/resources/**/*.json
 src/test/resources/**/*.base64
 src/test/resources/**/*.teal
 src/test/resources/**/*.tok
+src/test/resources/**/*.txt
 
 # OS X
 .DS_Store


### PR DESCRIPTION
Ignores copied over txt test resource files to prevent incidental versioning.

Without the change, running `make test` produces these untracked changes:
```
➤ Untracked files
#
#      untracked: [3] src/test/resources/v2algodclient_responsejsons/
#
```

The .txt files in-question stem from https://github.com/algorand/algorand-sdk-testing/pull/161.