### PR TITLE
Bug-Fix: Pass verbosity to the harness and sandbox

### DIFF
--- a/test-harness.sh
+++ b/test-harness.sh
@@ -15,6 +15,8 @@ set +a
 rootdir=$(dirname "$0")
 pushd "$rootdir"
 
+echo "$THIS: VERBOSE_HARNESS=$VERBOSE_HARNESS"
+
 ## Reset test harness
 if [ -d "$SDK_TESTING_HARNESS" ]; then
   pushd "$SDK_TESTING_HARNESS"
@@ -28,12 +30,13 @@ fi
 git clone --depth 1 --single-branch --branch "$SDK_TESTING_BRANCH" "$SDK_TESTING_URL" "$SDK_TESTING_HARNESS"
 
 
+echo "$THIS: OVERWRITE_TESTING_ENVIRONMENT=$OVERWRITE_TESTING_ENVIRONMENT"
 if [[ $OVERWRITE_TESTING_ENVIRONMENT == 1 ]]; then
   echo "$THIS: OVERWRITE replaced $SDK_TESTING_HARNESS/.env with $ENV_FILE:"
   cp "$ENV_FILE" "$SDK_TESTING_HARNESS"/.env
 fi
 
-## Copy feature files into the project resources
+echo "$THIS: REMOVE_LOCAL_FEATURES=$REMOVE_LOCAL_FEATURES"## Copy feature files into the project resources
 if [[ $REMOVE_LOCAL_FEATURES == 1 ]]; then
   echo "$THIS: OVERWRITE wipes clean $TEST_DIR/features"
   if [[ $VERBOSE_HARNESS == 1 ]]; then
@@ -62,7 +65,11 @@ echo "$THIS: seconds it took to get to end of cloning and copying: $(($(date "+%
 
 ## Start test harness environment
 pushd "$SDK_TESTING_HARNESS"
-./scripts/up.sh
+
+[[ "$VERBOSE_HARNESS" = 1 ]] && V_FLAG="-v" || V_FLAG=""
+echo "$THIS: standing up harnness with command [./up.sh $V_FLAG]"
+./scripts/up.sh "$V_FLAG"
+
 popd
 echo "$THIS: seconds it took to finish testing sdk's up.sh: $(($(date "+%s") - START))s"
 echo ""


### PR DESCRIPTION
# Summary

Following up from the companion [SDK Testing Bugfix PR](https://github.com/algorand/algorand-sdk-testing/pull/224), we're going to pass through verbosity to the harness script via a new `-v` flag.

For further context: here is what [SDK Testing Bugfix PR](https://github.com/algorand/algorand-sdk-testing/pull/224) says:
> The sandbox is always defaulting to `release` and the generated `config.harness` isn't sticking because the verbose flag is provided in the wrong order. 
> 
> Additionally, after refactoring the SDK Sandboxization PR's to no longer overwrite `.env`, there is no way to pass through the verbosity, except by overwriting. The PR re-enables passing through by also reading `VERBOSE_HARNESS` as a flag (either `-v` or `--verbose`).
