### PR TITLE
Deprecation: Add deprecation tags to v1 `algod` API

### DIFF
--- a/src/main/java/com/algorand/algosdk/abi/Contract.java
+++ b/src/main/java/com/algorand/algosdk/abi/Contract.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.abi;
 
-import com.algorand.algosdk.algod.client.StringUtil;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/algorand/algosdk/abi/Interface.java
+++ b/src/main/java/com/algorand/algosdk/abi/Interface.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.abi;
 
-import com.algorand.algosdk.algod.client.StringUtil;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/algorand/algosdk/abi/Method.java
+++ b/src/main/java/com/algorand/algosdk/abi/Method.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.abi;
 
-import com.algorand.algosdk.algod.client.StringUtil;
 import com.algorand.algosdk.transaction.Transaction;
 import com.algorand.algosdk.util.CryptoProvider;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,6 +18,8 @@ import java.util.ArrayList;
 import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Method {
@@ -150,7 +151,7 @@ public class Method {
     public String getSignature() {
         List<String> argStringList = new ArrayList<>();
         for (Arg value : this.args) argStringList.add(value.type);
-        return this.name + "(" + StringUtil.join(argStringList.toArray(new String[0]), ",") + ")" + this.returns.type;
+        return this.name + "(" + StringUtils.join(argStringList.toArray(new String[0]), ",") + ")" + this.returns.type;
     }
 
     @JsonIgnore
@@ -195,7 +196,7 @@ public class Method {
             for(int idx=0;idx<filteredMethods.size();idx++){
                sigs[idx] = filteredMethods.get(idx).getSignature();
             }
-            String found = StringUtil.join(sigs, ",");
+            String found = StringUtils.join(sigs, ",");
             throw new IllegalArgumentException(String.format("found %d methods with the same name: %s", filteredMethods.size(), found));
         }
 

--- a/src/main/java/com/algorand/algosdk/abi/TypeTuple.java
+++ b/src/main/java/com/algorand/algosdk/abi/TypeTuple.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.abi;
 
-import com.algorand.algosdk.algod.client.StringUtil;
 import com.algorand.algosdk.util.Encoder;
 import com.algorand.algosdk.util.GenericObjToArray;
 
@@ -10,6 +9,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 
 public class TypeTuple extends ABIType {
     public final List<ABIType> childTypes;
@@ -23,7 +24,7 @@ public class TypeTuple extends ABIType {
         List<String> childStrs = new ArrayList<>();
         for (ABIType t : this.childTypes)
             childStrs.add(t.toString());
-        return "(" + StringUtil.join(childStrs.toArray(new String[0]), ",") + ")";
+        return "(" + StringUtils.join(childStrs.toArray(new String[0]), ",") + ")";
     }
 
     @Override

--- a/src/main/java/com/algorand/algosdk/algod/client/AlgodClient.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/AlgodClient.java
@@ -1,4 +1,5 @@
 package com.algorand.algosdk.algod.client;
 
+@Deprecated
 public class AlgodClient extends ApiClient {
 }

--- a/src/main/java/com/algorand/algosdk/algod/client/ApiCallback.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ApiCallback.java
@@ -22,7 +22,9 @@ import java.util.List;
  * Callback for asynchronous API call.
  *
  * @param <T> The return type
+ * @deprecated Use the equivalent in v2 algod client
  */
+@Deprecated
 public interface ApiCallback<T> {
     /**
      * This is called when the API call fails.

--- a/src/main/java/com/algorand/algosdk/algod/client/ApiClient.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ApiClient.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
+@Deprecated
 public class ApiClient {
 
     private String basePath = "http://localhost";

--- a/src/main/java/com/algorand/algosdk/algod/client/ApiException.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ApiException.java
@@ -16,7 +16,7 @@ package com.algorand.algosdk.algod.client;
 import java.util.Map;
 import java.util.List;
 
-
+@Deprecated
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/ApiResponse.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ApiResponse.java
@@ -20,7 +20,9 @@ import java.util.Map;
  * API response returned by API call.
  *
  * @param <T> The type of data that is deserialized from response body
+ * @deprecated Use the equivalent in v2 algod client
  */
+@Deprecated
 public class ApiResponse<T> {
     final private int statusCode;
     final private Map<String, List<String>> headers;

--- a/src/main/java/com/algorand/algosdk/algod/client/Configuration.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/Configuration.java
@@ -13,7 +13,7 @@
 
 package com.algorand.algosdk.algod.client;
 
-
+@Deprecated
 public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/src/main/java/com/algorand/algosdk/algod/client/GzipRequestInterceptor.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/GzipRequestInterceptor.java
@@ -26,6 +26,7 @@ import java.io.IOException;
  *
  * Taken from https://github.com/square/okhttp/issues/350
  */
+@Deprecated
 class GzipRequestInterceptor implements Interceptor {
     @Override public Response intercept(Chain chain) throws IOException {
         Request originalRequest = chain.request();

--- a/src/main/java/com/algorand/algosdk/algod/client/JSON.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/JSON.java
@@ -32,6 +32,7 @@ import java.text.ParsePosition;
 import java.util.Date;
 import java.util.Map;
 
+@Deprecated
 public class JSON {
     private Gson gson;
     private boolean isLenientOnJson = false;

--- a/src/main/java/com/algorand/algosdk/algod/client/ProgressRequestBody.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ProgressRequestBody.java
@@ -24,6 +24,7 @@ import okio.ForwardingSink;
 import okio.Okio;
 import okio.Sink;
 
+@Deprecated
 public class ProgressRequestBody extends RequestBody {
 
     public interface ProgressRequestListener {

--- a/src/main/java/com/algorand/algosdk/algod/client/ProgressResponseBody.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/ProgressResponseBody.java
@@ -24,6 +24,7 @@ import okio.ForwardingSource;
 import okio.Okio;
 import okio.Source;
 
+@Deprecated
 public class ProgressResponseBody extends ResponseBody {
 
     public interface ProgressListener {

--- a/src/main/java/com/algorand/algosdk/algod/client/StringUtil.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/StringUtil.java
@@ -13,7 +13,7 @@
 
 package com.algorand.algosdk.algod.client;
 
-
+@Deprecated
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/com/algorand/algosdk/algod/client/api/AlgodApi.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/api/AlgodApi.java
@@ -4,6 +4,10 @@ import com.algorand.algosdk.algod.client.AlgodClient;
 import com.algorand.algosdk.algod.client.ApiClient;
 import com.algorand.algosdk.algod.client.Configuration;
 
+/**
+ * @deprecated Use the equivalent in v2 algod client
+ */
+@Deprecated
 public class AlgodApi extends DefaultApi {
 
     public AlgodApi() {

--- a/src/main/java/com/algorand/algosdk/algod/client/api/DefaultApi.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/api/DefaultApi.java
@@ -26,6 +26,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @deprecated Use the equivalent in v2 algod client
+ */
+@Deprecated
 public class DefaultApi {
     private ApiClient apiClient;
 

--- a/src/main/java/com/algorand/algosdk/algod/client/auth/ApiKeyAuth.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/auth/ApiKeyAuth.java
@@ -18,7 +18,7 @@ import com.algorand.algosdk.algod.client.lib.Pair;
 import java.util.List;
 import java.util.Map;
 
-
+@Deprecated
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/com/algorand/algosdk/algod/client/auth/Authentication.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/auth/Authentication.java
@@ -18,6 +18,7 @@ import com.algorand.algosdk.algod.client.lib.Pair;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated
 public interface Authentication {
     /**
      * Apply authentication settings to header and query params.

--- a/src/main/java/com/algorand/algosdk/algod/client/auth/HttpBasicAuth.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/auth/HttpBasicAuth.java
@@ -19,6 +19,7 @@ import com.squareup.okhttp.Credentials;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated
 public class HttpBasicAuth implements Authentication {
     private String username;
     private String password;

--- a/src/main/java/com/algorand/algosdk/algod/client/auth/OAuth.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/auth/OAuth.java
@@ -18,7 +18,7 @@ import com.algorand.algosdk.algod.client.lib.Pair;
 import java.util.List;
 import java.util.Map;
 
-
+@Deprecated
 public class OAuth implements Authentication {
   private String accessToken;
 

--- a/src/main/java/com/algorand/algosdk/algod/client/auth/OAuthFlow.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/auth/OAuthFlow.java
@@ -13,6 +13,7 @@
 
 package com.algorand.algosdk.algod.client.auth;
 
+@Deprecated
 public enum OAuthFlow {
     accessCode, implicit, password, application
 }

--- a/src/main/java/com/algorand/algosdk/algod/client/lib/Pair.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/lib/Pair.java
@@ -13,7 +13,7 @@
 
 package com.algorand.algosdk.algod.client.lib;
 
-
+@Deprecated
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/com/algorand/algosdk/algod/client/model/Account.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/Account.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.ObjectUtils;
  */
 @ApiModel(description = "Account Description")
 
+@Deprecated
 public class Account {
   @SerializedName("address")
   private String address = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/AssetHolding.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/AssetHolding.java
@@ -15,6 +15,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(description = "AssetParams specifies the holdings of a particular asset.")
+@Deprecated
 public class AssetHolding {
   @SerializedName("creator")
   private String creator = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/AssetParams.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/AssetParams.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 
 @ApiModel(description = "AssetParams specifies the parameters for an asset")
+@Deprecated
 public class AssetParams {
   @SerializedName("assetname")
   private String assetname = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/Block.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/Block.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * Block contains a block information
  */
 @ApiModel(description = "Block contains a block information")
-
+@Deprecated
 public class Block {
   @SerializedName("currentProtocol")
   private String currentProtocol = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/NodeStatus.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/NodeStatus.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * NodeStatus contains the information about a node status
  */
 @ApiModel(description = "NodeStatus contains the information about a node status")
-
+@Deprecated
 public class NodeStatus {
   @SerializedName("catchupTime")
   private java.math.BigInteger catchupTime = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/Participation.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/Participation.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Participation Description
  */
 @ApiModel(description = "Participation Description")
-
+@Deprecated
 public class Participation {
   @SerializedName("partpkb64")
   private byte[] partpkb64 = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/PaymentTransactionType.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/PaymentTransactionType.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * PaymentTransactionType contains the additional fields for a payment Transaction
  */
 @ApiModel(description = "PaymentTransactionType contains the additional fields for a payment Transaction")
-
+@Deprecated
 public class PaymentTransactionType {
   @SerializedName("amount")
   private java.math.BigInteger amount = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/PendingTransactions.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/PendingTransactions.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * PendingTransactions represents a potentially truncated list of transactions currently in the node&#39;s transaction pool.
  */
 @ApiModel(description = "PendingTransactions represents a potentially truncated list of transactions currently in the node's transaction pool.")
-
+@Deprecated
 public class PendingTransactions {
   @SerializedName("totalTxns")
   private java.math.BigInteger totalTxns = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/Supply.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/Supply.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * Supply represents the current supply of MicroAlgos in the system
  */
 @ApiModel(description = "Supply represents the current supply of MicroAlgos in the system")
-
+@Deprecated
 public class Supply {
   @SerializedName("onlineMoney")
   private java.math.BigInteger onlineMoney = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/Transaction.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * Transaction contains all fields common to all transactions and serves as an envelope to all transactions type
  */
 @ApiModel(description = "Transaction contains all fields common to all transactions and serves as an envelope to all transactions type")
-
+@Deprecated
 public class Transaction {
   @SerializedName("fee")
   private java.math.BigInteger fee = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/TransactionFee.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/TransactionFee.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * TransactionFee contains the suggested fee
  */
 @ApiModel(description = "TransactionFee contains the suggested fee")
-
+@Deprecated
 public class TransactionFee {
   @SerializedName("fee")
   private java.math.BigInteger fee = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/TransactionID.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/TransactionID.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * TransactionID Description
  */
 @ApiModel(description = "TransactionID Description")
-
+@Deprecated
 public class TransactionID {
   @SerializedName("txId")
   private String txId = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/TransactionList.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/TransactionList.java
@@ -25,7 +25,7 @@ import java.util.List;
  * TransactionList contains a list of transactions
  */
 @ApiModel(description = "TransactionList contains a list of transactions")
-
+@Deprecated
 public class TransactionList {
   @SerializedName("transactions")
   private List<Transaction> transactions = new ArrayList<Transaction>();

--- a/src/main/java/com/algorand/algosdk/algod/client/model/TransactionParams.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/TransactionParams.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.ObjectUtils;
  * TransactionParams contains the parameters that help a client construct a new transaction.
  */
 @ApiModel(description = "TransactionParams contains the parameters that help a client construct a new transaction.")
-
+@Deprecated
 public class TransactionParams {
   @SerializedName("consensusVersion")
   private String consensusVersion = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/TransactionResults.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/TransactionResults.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * TransactionResults contains information about the side effects of a transaction
  */
 @ApiModel(description = "TransactionResults contains information about the side effects of a transaction")
-
+@Deprecated
 public class TransactionResults {
   @SerializedName("createdasset")
   private java.math.BigInteger createdasset = null;

--- a/src/main/java/com/algorand/algosdk/algod/client/model/Version.java
+++ b/src/main/java/com/algorand/algosdk/algod/client/model/Version.java
@@ -25,7 +25,7 @@ import java.util.List;
  * Note that we annotate this as a model so that legacy clients can directly import a swagger generated Version model.
  */
 @ApiModel(description = "Note that we annotate this as a model so that legacy clients can directly import a swagger generated Version model.")
-
+@Deprecated
 public class Version {
   @SerializedName("genesis_hash_b64")
   private byte[] genesisHashB64 = null;


### PR DESCRIPTION
This PR adds deprecation tags to the Javadocs to v1 algod APIs and related models/utilities.

Related issue here: https://github.com/algorand/algorand-sdk-testing/issues/218