### PR TITLE
Remove boxReferences from public Transaction constructor

### DIFF
--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -742,7 +742,7 @@ public class Transaction implements Serializable {
         );
         // Set fields _not_ exposed by public constructor.  Needed because:
         // * Adding parameters to a public constructor is a breaking API change.
-        // * To ensure JSON serialization (via Jackson's ObjectMapper) works, must add `@JsonProperty` to _a_ constructor.  Using a private constructor here to maintain API backwards compatibility.
+        // * To ensure JSON/msgpack serialization (via Jackson's ObjectMapper) works, must add `@JsonProperty` to _a_ constructor.  Using a private constructor here to maintain API backwards compatibility.
         if (boxReferences != null) this.boxReferences = boxReferences;
     }
 

--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -683,6 +683,7 @@ public class Transaction implements Serializable {
                         @JsonProperty("apat") List<byte[]> accounts,
                         @JsonProperty("apfa") List<Long> foreignApps,
                         @JsonProperty("apas") List<Long> foreignAssets,
+                        @JsonProperty("apbx") List<BoxReference> boxReferences,
                         @JsonProperty("apgs") StateSchema globalStateSchema,
                         @JsonProperty("apid") Long applicationId,
                         @JsonProperty("apls") StateSchema localStateSchema,
@@ -739,6 +740,10 @@ public class Transaction implements Serializable {
                 clearStateProgram == null ? null : new TEALProgram(clearStateProgram),
                 extraPages
         );
+        // Set fields _not_ exposed by public constructor.  Needed because:
+        // * Adding parameters to a public constructor is a breaking API change.
+        // * To ensure JSON serialization (via Jackson's ObjectMapper) works, must add `@JsonProperty` to _a_ constructor.  Using a private constructor here to maintain API backwards compatibility.
+        if (boxReferences != null) this.boxReferences = boxReferences;
     }
 
     /**

--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -302,7 +302,6 @@ public class Transaction implements Serializable {
                 null,
                 null,
                 null,
-                null,
                 null);
     }
 
@@ -397,7 +396,6 @@ public class Transaction implements Serializable {
                 null,
                 null,
                 false, // default value which wont be included in the serialized object.
-                null,
                 null,
                 null,
                 null,
@@ -525,7 +523,6 @@ public class Transaction implements Serializable {
                 null,
                 null,
                 false, // default value which wont be included in the serialized object.
-                null,
                 null,
                 null,
                 null,
@@ -686,7 +683,6 @@ public class Transaction implements Serializable {
                         @JsonProperty("apat") List<byte[]> accounts,
                         @JsonProperty("apfa") List<Long> foreignApps,
                         @JsonProperty("apas") List<Long> foreignAssets,
-                        @JsonProperty("apbx") List<BoxReference> boxReferences,
                         @JsonProperty("apgs") StateSchema globalStateSchema,
                         @JsonProperty("apid") Long applicationId,
                         @JsonProperty("apls") StateSchema localStateSchema,
@@ -737,7 +733,6 @@ public class Transaction implements Serializable {
                 convertToAddressList(accounts),
                 foreignApps,
                 foreignAssets,
-                boxReferences,
                 globalStateSchema,
                 applicationId,
                 localStateSchema,
@@ -795,7 +790,6 @@ public class Transaction implements Serializable {
             List<Address> accounts,
             List<Long> foreignApps,
             List<Long> foreignAssets,
-            List<BoxReference> boxReferences,
             StateSchema globalStateSchema,
             Long applicationId,
             StateSchema localStateSchema,
@@ -846,7 +840,6 @@ public class Transaction implements Serializable {
                 accounts,
                 foreignApps,
                 foreignAssets,
-                boxReferences,
                 globalStateSchema,
                 applicationId,
                 localStateSchema,
@@ -905,7 +898,6 @@ public class Transaction implements Serializable {
             List<Address> accounts,
             List<Long> foreignApps,
             List<Long> foreignAssets,
-            List<BoxReference> boxReferences,
             StateSchema globalStateSchema,
             Long applicationId,
             StateSchema localStateSchema,
@@ -949,7 +941,6 @@ public class Transaction implements Serializable {
         if (accounts != null) this.accounts = accounts;
         if (foreignApps != null) this.foreignApps = foreignApps;
         if (foreignAssets != null) this.foreignAssets = foreignAssets;
-        if (boxReferences != null) this.boxReferences = boxReferences;
         if (globalStateSchema != null) this.globalStateSchema = globalStateSchema;
         if (applicationId != null) this.applicationId = applicationId;
         if (localStateSchema != null) this.localStateSchema = globalStateSchema;


### PR DESCRIPTION
Addresses https://github.com/algorand/java-algorand-sdk/pull/345#discussion_r976865846 by removing breaking changes to `Transaction` public constructor.

Since serialization relies on runtime annotation inspection, the PR must preserve box reference as a private constructor parameter.