### PR TITLE
Rework MethodCallParams to be backwards compatible with Boxes

### DIFF
--- a/src/main/java/com/algorand/algosdk/builder/transaction/MethodCallTransactionBuilder.java
+++ b/src/main/java/com/algorand/algosdk/builder/transaction/MethodCallTransactionBuilder.java
@@ -2,6 +2,7 @@ package com.algorand.algosdk.builder.transaction;
 
 import com.algorand.algosdk.abi.Method;
 import com.algorand.algosdk.crypto.Address;
+import com.algorand.algosdk.crypto.Digest;
 import com.algorand.algosdk.crypto.TEALProgram;
 import com.algorand.algosdk.logic.StateSchema;
 import com.algorand.algosdk.transaction.AppBoxReference;
@@ -9,6 +10,7 @@ import com.algorand.algosdk.transaction.MethodCallParams;
 import com.algorand.algosdk.transaction.Transaction;
 import com.algorand.algosdk.transaction.TxnSigner;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -174,10 +176,34 @@ public class MethodCallTransactionBuilder<T extends MethodCallTransactionBuilder
      * Build a MethodCallParams object.
      */
     public MethodCallParams build() {
-        return new MethodCallParams(
-                appID, method, methodArgs, sender, onCompletion, note, lease, genesisID, genesisHash,
+        return new MethodCallParamsFactory(appID, method, methodArgs, sender, onCompletion, note, lease, genesisID, genesisHash,
                 firstValid, lastValid, fee, flatFee, rekeyTo, signer, foreignAccounts, foreignAssets, foreignApps,
-                boxReferences, approvalProgram, clearStateProgram, globalStateSchema, localStateSchema, extraPages
-        );
+                boxReferences, approvalProgram, clearStateProgram, globalStateSchema, localStateSchema, extraPages);
+    }
+
+    /**
+     * MethodCallParamsFactory exists only as a way to facilitate construction of
+     * `MethodCallParams` instances via a protected constructor.
+     * <p>
+     * No extension or other modification is intended.
+     */
+    private static class MethodCallParamsFactory extends MethodCallParams {
+
+        MethodCallParamsFactory(Long appID, Method method, List<Object> methodArgs, Address sender,
+                                Transaction.OnCompletion onCompletion, byte[] note, byte[] lease, String genesisID, Digest genesisHash,
+                                BigInteger firstValid, BigInteger lastValid, BigInteger fee, BigInteger flatFee,
+                                Address rekeyTo, TxnSigner signer,
+                                List<Address> fAccounts, List<Long> fAssets, List<Long> fApps, List<AppBoxReference> boxes,
+                                TEALProgram approvalProgram, TEALProgram clearProgram,
+                                StateSchema globalStateSchema, StateSchema localStateSchema, Long extraPages) {
+            super(appID, method, methodArgs, sender,
+                    onCompletion, note, lease, genesisID, genesisHash,
+                    firstValid, lastValid, fee, flatFee,
+                    rekeyTo, signer,
+                    fAccounts, fAssets, fApps, boxes,
+                    approvalProgram, clearProgram,
+                    globalStateSchema, localStateSchema, extraPages);
+        }
+
     }
 }

--- a/src/main/java/com/algorand/algosdk/transaction/MethodCallParams.java
+++ b/src/main/java/com/algorand/algosdk/transaction/MethodCallParams.java
@@ -36,7 +36,7 @@ public class MethodCallParams {
     public final List<Address> foreignAccounts;
     public final List<Long> foreignAssets;
     public final List<Long> foreignApps;
-    public List<AppBoxReference> boxReferences;
+    public final List<AppBoxReference> boxReferences;
 
     public final TEALProgram approvalProgram, clearProgram;
     public final StateSchema globalStateSchema, localStateSchema;

--- a/src/main/java/com/algorand/algosdk/transaction/MethodCallParams.java
+++ b/src/main/java/com/algorand/algosdk/transaction/MethodCallParams.java
@@ -22,6 +22,7 @@ import java.util.List;
  * MethodCallParams is an object that holds all parameters necessary to invoke {@link AtomicTransactionComposer#addMethodCall(MethodCallParams)}
  */
 public class MethodCallParams {
+
     // if the abi type argument number > 15, then the abi types after 14th should be wrapped in a tuple
     private static final int MAX_ABI_ARG_TYPE_LEN = 15;
 
@@ -35,7 +36,7 @@ public class MethodCallParams {
     public final List<Address> foreignAccounts;
     public final List<Long> foreignAssets;
     public final List<Long> foreignApps;
-    public final List<AppBoxReference> boxReferences;
+    public List<AppBoxReference> boxReferences;
 
     public final TEALProgram approvalProgram, clearProgram;
     public final StateSchema globalStateSchema, localStateSchema;
@@ -55,17 +56,13 @@ public class MethodCallParams {
     public final String genesisID;
     public final Digest genesisHash;
 
-    /**
-     * NOTE: it's strongly suggested to use {@link com.algorand.algosdk.builder.transaction.MethodCallTransactionBuilder}
-     * instead of this constructor to create a new MethodCallParams object.
-     */
-    public MethodCallParams(Long appID, Method method, List<Object> methodArgs, Address sender,
-                            Transaction.OnCompletion onCompletion, byte[] note, byte[] lease, String genesisID, Digest genesisHash,
-                            BigInteger firstValid, BigInteger lastValid, BigInteger fee, BigInteger flatFee,
-                            Address rekeyTo, TxnSigner signer,
-                            List<Address> fAccounts, List<Long> fAssets, List<Long> fApps, List<AppBoxReference> boxes,
-                            TEALProgram approvalProgram, TEALProgram clearProgram,
-                            StateSchema globalStateSchema, StateSchema localStateSchema, Long extraPages) {
+    protected MethodCallParams(Long appID, Method method, List<Object> methodArgs, Address sender,
+                               Transaction.OnCompletion onCompletion, byte[] note, byte[] lease, String genesisID, Digest genesisHash,
+                               BigInteger firstValid, BigInteger lastValid, BigInteger fee, BigInteger flatFee,
+                               Address rekeyTo, TxnSigner signer,
+                               List<Address> fAccounts, List<Long> fAssets, List<Long> fApps, List<AppBoxReference> boxes,
+                               TEALProgram approvalProgram, TEALProgram clearProgram,
+                               StateSchema globalStateSchema, StateSchema localStateSchema, Long extraPages) {
         if (appID == null || method == null || sender == null || onCompletion == null || signer == null || genesisID == null || genesisHash == null || firstValid == null || lastValid == null || (fee == null && flatFee == null))
             throw new IllegalArgumentException("Method call builder error: some required field not added");
         if (fee != null && flatFee != null)
@@ -120,6 +117,27 @@ public class MethodCallParams {
         this.globalStateSchema = globalStateSchema;
         this.localStateSchema = localStateSchema;
         this.extraPages = extraPages;
+    }
+
+    /**
+     * Deprecated - Use {@link com.algorand.algosdk.builder.transaction.MethodCallTransactionBuilder}
+     * to create a new MethodCallParams object instead.
+     */
+    @Deprecated
+    public MethodCallParams(Long appID, Method method, List<Object> methodArgs, Address sender,
+                            Transaction.OnCompletion onCompletion, byte[] note, byte[] lease, String genesisID, Digest genesisHash,
+                            BigInteger firstValid, BigInteger lastValid, BigInteger fee, BigInteger flatFee,
+                            Address rekeyTo, TxnSigner signer,
+                            List<Address> fAccounts, List<Long> fAssets, List<Long> fApps,
+                            TEALProgram approvalProgram, TEALProgram clearProgram,
+                            StateSchema globalStateSchema, StateSchema localStateSchema, Long extraPages) {
+        this(appID, method, methodArgs, sender,
+                onCompletion, note, lease, genesisID, genesisHash,
+                firstValid, lastValid, fee, flatFee,
+                rekeyTo, signer,
+                fAccounts, fAssets, fApps, new ArrayList(),
+                approvalProgram, clearProgram,
+                globalStateSchema, localStateSchema, extraPages);
     }
 
     /**


### PR DESCRIPTION
Reworks `MethodCallParams` to be backwards compatible with Boxes by making a protected constructor available to the builder.  Additionally, deprecates the public constructor to clearly warn about usage.