### PR TITLE
SDK: Fix transaction decoding with boxes

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="master"
+SDK_TESTING_BRANCH="app-txn-decode"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="app-txn-decode"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0

--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -1585,7 +1585,7 @@ public class Transaction implements Serializable {
                 @JsonProperty("i") int appIndex,
                 @JsonProperty("n") byte[] name) {
             this.appIndex = appIndex;
-            this.name = Arrays.copyOf(name, name.length);
+            this.name = name == null ? new byte[]{} : Arrays.copyOf(name, name.length);
         }
 
         // Foreign apps start from index 1.  Index 0 is the called App ID.

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -158,6 +158,31 @@ public class TestTransaction {
     }
 
     @Test
+    public void testEmptyBoxReferenceSerializationMsgpack() throws Exception {
+        Transaction.BoxReference boxReference = new Transaction.BoxReference(0, new byte[]{});
+
+        byte[] encoded = Encoder.encodeToMsgPack(boxReference);
+        byte[] expectedEncoded = {(byte) 128};
+        assertThat(encoded).isEqualTo(expectedEncoded);
+
+        Transaction.BoxReference decoded = Encoder.decodeFromMsgPack(encoded, Transaction.BoxReference.class);
+        assertThat(decoded).isEqualTo(boxReference);
+    }
+
+    @Test
+    public void testEmptyBoxReferenceSerializationJson() throws Exception {
+        Transaction.BoxReference boxReference = new Transaction.BoxReference(0, new byte[]{});
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String encoded = objectMapper.writeValueAsString(boxReference);
+        String expectedEncoded = "{}";
+        assertThat(encoded).isEqualTo(expectedEncoded);
+
+        Transaction.BoxReference decoded = objectMapper.readValue(encoded, Transaction.BoxReference.class);
+        assertThat(decoded).isEqualTo(boxReference);
+    }
+
+    @Test
     public void testMetadaHashBuilderMethods() throws Exception {
         // Test that the following 3 builder methods returns the same transaction
         //    metadataHash, metadataHashUTF8, and metadataHashB64


### PR DESCRIPTION
This PR fixes a bug when decoding transactions with box references. This SDK should now pass the test changes from https://github.com/algorand/algorand-sdk-testing/pull/248