### PR TITLE
Remove deprecated TxGroup.assignGroupID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.0
+
+## Breaking changes
+
+* Remove `TxGroup.assignGroupID(Transaction[] txns, Address address)` in favor
+  of `TxGroup.assignGroupID(Address address, Transaction ...txns)`.
+
 # 1.22.0
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,27 @@
+# 2.0.0
+
+## Breaking changes
+
+* Remove `TxGroup.assignGroupID(Transaction[] txns, Address address)` in favor
+  of `TxGroup.assignGroupID(Address address, Transaction ...txns)`.
+
 # 1.22.0
 
 ### Bugfixes
-* BugFix: Fix incorrect reference to global schema by @barnjamin in https://github.com/algorand/java-algorand-sdk/pull/427
-* Bug-Fix: parsing type strings for tuples containing static arrays of tuples by @ahangsu in https://github.com/algorand/java-algorand-sdk/pull/431
-### Enhancements
-* REST API: Add KV counts to NodeStatusResponse by @github-actions in https://github.com/algorand/java-algorand-sdk/pull/428
-* Enhancement: Migrate v1 algod dependencies to v2 in cucumber tests by @ahangsu in https://github.com/algorand/java-algorand-sdk/pull/425
-* Enhancement: Allowing zero length in static array by @ahangsu in https://github.com/algorand/java-algorand-sdk/pull/432
 
+* BugFix: Fix incorrect reference to global schema by @barnjamin
+  in https://github.com/algorand/java-algorand-sdk/pull/427
+* Bug-Fix: parsing type strings for tuples containing static arrays of tuples by @ahangsu
+  in https://github.com/algorand/java-algorand-sdk/pull/431
+
+### Enhancements
+
+* REST API: Add KV counts to NodeStatusResponse by @github-actions
+  in https://github.com/algorand/java-algorand-sdk/pull/428
+* Enhancement: Migrate v1 algod dependencies to v2 in cucumber tests by @ahangsu
+  in https://github.com/algorand/java-algorand-sdk/pull/425
+* Enhancement: Allowing zero length in static array by @ahangsu
+  in https://github.com/algorand/java-algorand-sdk/pull/432
 
 **Full Changelog**: https://github.com/algorand/java-algorand-sdk/compare/1.21.1...1.22.0
 
@@ -212,10 +226,11 @@
 - Fix javadoc and build pom.xml.
 
 # 1.3.0
+
 - Added additional Algorand Smart Contracts (ASC)
-    - Added support for Dynamic Fee contract
-    - Added support for Limit Order contract
-    - Added support for Periodic Payment contract
+  - Added support for Dynamic Fee contract
+  - Added support for Limit Order contract
+  - Added support for Periodic Payment contract
 - Added new builder patterns for creating Transactions, see com.algorand.algosdk.builder.transaction.*
 - Add missing getters to AssetHolding model object.
 
@@ -225,10 +240,11 @@
 
 # 1.2.0
 # Added
+
 - Added support for Algorand Standardized Assets (ASA)
 - Added support for Algorand Smart Contracts (ASC)
-    - Added support for Hashed Time Lock Contract (HTLC)
-    - Added support for Split contract
+  - Added support for Hashed Time Lock Contract (HTLC)
+  - Added support for Split contract
 - Added support for Group Transactions
 - Added support for leases
 # 1.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,13 @@
-# 2.0.0
-
-## Breaking changes
-
-* Remove `TxGroup.assignGroupID(Transaction[] txns, Address address)` in favor
-  of `TxGroup.assignGroupID(Address address, Transaction ...txns)`.
-
 # 1.22.0
 
 ### Bugfixes
-
-* BugFix: Fix incorrect reference to global schema by @barnjamin
-  in https://github.com/algorand/java-algorand-sdk/pull/427
-* Bug-Fix: parsing type strings for tuples containing static arrays of tuples by @ahangsu
-  in https://github.com/algorand/java-algorand-sdk/pull/431
-
+* BugFix: Fix incorrect reference to global schema by @barnjamin in https://github.com/algorand/java-algorand-sdk/pull/427
+* Bug-Fix: parsing type strings for tuples containing static arrays of tuples by @ahangsu in https://github.com/algorand/java-algorand-sdk/pull/431
 ### Enhancements
+* REST API: Add KV counts to NodeStatusResponse by @github-actions in https://github.com/algorand/java-algorand-sdk/pull/428
+* Enhancement: Migrate v1 algod dependencies to v2 in cucumber tests by @ahangsu in https://github.com/algorand/java-algorand-sdk/pull/425
+* Enhancement: Allowing zero length in static array by @ahangsu in https://github.com/algorand/java-algorand-sdk/pull/432
 
-* REST API: Add KV counts to NodeStatusResponse by @github-actions
-  in https://github.com/algorand/java-algorand-sdk/pull/428
-* Enhancement: Migrate v1 algod dependencies to v2 in cucumber tests by @ahangsu
-  in https://github.com/algorand/java-algorand-sdk/pull/425
-* Enhancement: Allowing zero length in static array by @ahangsu
-  in https://github.com/algorand/java-algorand-sdk/pull/432
 
 **Full Changelog**: https://github.com/algorand/java-algorand-sdk/compare/1.21.1...1.22.0
 
@@ -226,11 +212,10 @@
 - Fix javadoc and build pom.xml.
 
 # 1.3.0
-
 - Added additional Algorand Smart Contracts (ASC)
-  - Added support for Dynamic Fee contract
-  - Added support for Limit Order contract
-  - Added support for Periodic Payment contract
+    - Added support for Dynamic Fee contract
+    - Added support for Limit Order contract
+    - Added support for Periodic Payment contract
 - Added new builder patterns for creating Transactions, see com.algorand.algosdk.builder.transaction.*
 - Add missing getters to AssetHolding model object.
 
@@ -240,11 +225,10 @@
 
 # 1.2.0
 # Added
-
 - Added support for Algorand Standardized Assets (ASA)
 - Added support for Algorand Smart Contracts (ASC)
-  - Added support for Hashed Time Lock Contract (HTLC)
-  - Added support for Split contract
+    - Added support for Hashed Time Lock Contract (HTLC)
+    - Added support for Split contract
 - Added support for Group Transactions
 - Added support for leases
 # 1.1.6

--- a/src/main/java/com/algorand/algosdk/transaction/TxGroup.java
+++ b/src/main/java/com/algorand/algosdk/transaction/TxGroup.java
@@ -58,7 +58,7 @@ public class TxGroup implements Serializable{
      * @return array of grouped transactions, optionally filtered with the address parameter.
      */
     public static Transaction[] assignGroupID(Transaction ...txns) throws IOException {
-        return assignGroupID(txns, null);
+        return assignGroupID(null, txns);
     }
 
     /**
@@ -68,23 +68,8 @@ public class TxGroup implements Serializable{
      * @return array of grouped transactions, optionally filtered with the address parameter.
      */
     public static Transaction[] assignGroupID(Address address, Transaction ...txns) throws IOException {
-        return assignGroupID(txns, address);
-    }
-
-    /**
-     * Assigns group id to a given array of unsigned transactions
-     * @param txns array of transactions
-     * @param address optional sender address specifying which transaction return
-     * @return array of grouped transactions, optionally filtered with the address parameter.
-     *
-     * @Deprecated use assignGroupID(address, Transaction ...txns)
-     */
-    @Deprecated // Jan 8, 2020
-    public static Transaction[] assignGroupID(
-        Transaction[] txns, Address address
-    ) throws IOException {
         Digest gid = TxGroup.computeGroupID(txns);
-        ArrayList<Transaction> result = new ArrayList<Transaction>();
+        ArrayList<Transaction> result = new ArrayList<>();
         for (Transaction tx : txns) {
             if (address == null || address.toString() == "" || address == tx.sender) {
                 tx.assignGroupID(gid);


### PR DESCRIPTION
While reviewing #443, I realized `assignGroupID` has been deprecated since https://github.com/algorand/java-algorand-sdk/pull/83/.  Since the method has been deprecated for > 2 years, the PR proposes removing it in v2.0.0.