### PR TITLE
Bug-Fix: update label github action to v3

### DIFF
--- a/.github/workflows/pr-type-category.yml
+++ b/.github/workflows/pr-type-category.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check PR Category and Type
     steps:
       - name: Checking for correct number of required github pr labels
-        uses: mheap/github-action-required-labels@v2
+        uses: mheap/github-action-required-labels@v3
         with:
           mode: exactly
           count: 1


### PR DESCRIPTION
## Summary
 - Upgrade label github action to `v3` (`v2` is deprecated)