### PR TITLE
DX: Allowing null for fee and flatfee in Long and Integer builder methods.

### DIFF
--- a/src/main/java/com/algorand/algosdk/builder/transaction/TransactionParametersBuilder.java
+++ b/src/main/java/com/algorand/algosdk/builder/transaction/TransactionParametersBuilder.java
@@ -103,8 +103,12 @@ public abstract class TransactionParametersBuilder<T extends TransactionParamete
      * @return This builder.
      */
     public T fee(Integer fee) {
-        if (fee < 0) throw new IllegalArgumentException("fee cannot be a negative value");
-        this.fee = BigInteger.valueOf(fee);
+        if (fee != null) {
+            if (fee < 0) throw new IllegalArgumentException("fee cannot be a negative value");
+            this.fee = BigInteger.valueOf(fee);
+        } else {
+            this.fee = null;
+        }
         return (T) this;
     }
 
@@ -115,8 +119,12 @@ public abstract class TransactionParametersBuilder<T extends TransactionParamete
      * @return This builder.
      */
     public T fee(Long fee) {
-        if (fee < 0) throw new IllegalArgumentException("fee cannot be a negative value");
-        this.fee = BigInteger.valueOf(fee);
+        if (fee != null) {
+            if (fee < 0) throw new IllegalArgumentException("fee cannot be a negative value");
+            this.fee = BigInteger.valueOf(fee);
+        } else {
+            this.fee = null;
+        }
         return (T) this;
     }
 
@@ -142,8 +150,12 @@ public abstract class TransactionParametersBuilder<T extends TransactionParamete
      * @return This builder.
      */
     public T flatFee(Integer flatFee) {
-        if (flatFee < 0) throw new IllegalArgumentException("flatFee cannot be a negative value");
-        this.flatFee = BigInteger.valueOf(flatFee);
+        if (flatFee != null) {
+            if (flatFee < 0) throw new IllegalArgumentException("flatFee cannot be a negative value");
+            this.flatFee = BigInteger.valueOf(flatFee);
+        } else {
+            this.flatFee = null;
+        }
         return (T) this;
     }
 
@@ -156,8 +168,12 @@ public abstract class TransactionParametersBuilder<T extends TransactionParamete
      * @return This builder.
      */
     public T flatFee(Long flatFee) {
-        if (flatFee < 0) throw new IllegalArgumentException("flatFee cannot be a negative value");
-        this.flatFee = BigInteger.valueOf(flatFee);
+        if (flatFee != null) {
+            if (flatFee < 0) throw new IllegalArgumentException("flatFee cannot be a negative value");
+            this.flatFee = BigInteger.valueOf(flatFee);
+        } else {
+            this.flatFee = null;
+        }
         return (T) this;
     }
 

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestTransaction {
@@ -279,6 +280,264 @@ public class TestTransaction {
         assertThat(txUTF8).isEqualTo(txB64);
         assertThat(txUTF8).isNotEqualTo(txUTF8Different);
     }
+
+    @Test
+    public void testFeeBuilderMethodWithNullValue() throws Exception {
+        // Test that the fee builder method accepts null for Long, Integer.
+        // The result should same as the output of BigInteger method.
+
+        String metadataHashUTF8 = "Hello! This is the metadata hash";
+        // The value below is the base64 of metadataHashUTF8
+        String metadataHashB64 = "SGVsbG8hIFRoaXMgaXMgdGhlIG1ldGFkYXRhIGhhc2g=";
+
+        Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");
+        byte[] gh = Encoder.decodeFromBase64("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+        Address sender = addr;
+        Address manager = addr;
+        Address reserve = addr;
+        Address freeze = addr;
+        Address clawback = addr;
+
+        Transaction txWhereFeeIsBigIntegerNull = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee((BigInteger) null)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+        Transaction txWhereFeeIsIntegerNull = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee((Integer) null)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+
+        Transaction txWhereFeeIsLongNull = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee((Long) null)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+
+
+        assertThat(txWhereFeeIsIntegerNull).isEqualTo(txWhereFeeIsBigIntegerNull);
+        assertThat(txWhereFeeIsLongNull).isEqualTo(txWhereFeeIsBigIntegerNull);
+    }
+
+    @Test
+    public void testFlatFeeBuilderMethodWithNullValue() throws Exception {
+        // Test that the fee builder method accepts null for Long, Integer.
+        // The result should same as the output of BigInteger method.
+
+        String metadataHashUTF8 = "Hello! This is the metadata hash";
+        // The value below is the base64 of metadataHashUTF8
+        String metadataHashB64 = "SGVsbG8hIFRoaXMgaXMgdGhlIG1ldGFkYXRhIGhhc2g=";
+
+        Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");
+        byte[] gh = Encoder.decodeFromBase64("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+        Address sender = addr;
+        Address manager = addr;
+        Address reserve = addr;
+        Address freeze = addr;
+        Address clawback = addr;
+
+        Transaction txWhereFlatFeeIsBigIntegerNull = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee(10)
+                .flatFee((BigInteger) null)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+        Transaction txWhereFlatFeeIsIntegerNull = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee(10)
+                .flatFee((Integer) null)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+
+        Transaction txWhereFlatFeeIsLongNull = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee(10)
+                .flatFee((Long) null)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+
+
+        assertThat(txWhereFlatFeeIsIntegerNull).isEqualTo(txWhereFlatFeeIsBigIntegerNull);
+        assertThat(txWhereFlatFeeIsLongNull).isEqualTo(txWhereFlatFeeIsBigIntegerNull);
+    }
+
+    @Test
+    public void testNullValuesOfFeeAndFlatFee() throws Exception {
+        // This test checks status of transaction for different fee and flatFee combination.
+
+        String metadataHashUTF8 = "Hello! This is the metadata hash";
+        // The value below is the base64 of metadataHashUTF8
+        String metadataHashB64 = "SGVsbG8hIFRoaXMgaXMgdGhlIG1ldGFkYXRhIGhhc2g=";
+
+        Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");
+        byte[] gh = Encoder.decodeFromBase64("SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+        Address sender = addr;
+        Address manager = addr;
+        Address reserve = addr;
+        Address freeze = addr;
+        Address clawback = addr;
+
+        // If flatFee is not present, but fee is present, set value of fee to supplied fee. If there is
+        // some problem, value is set to Account.MIN_TX_FEE_UALGOS.
+        Transaction txWhereFlatFeeIsNullFeeIsPresent = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee(10)
+                .flatFee((BigInteger) null)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+        assertThat(txWhereFlatFeeIsNullFeeIsPresent.fee).isEqualTo(4180);
+
+        // If flatFee is present, but fee is not present, set value of fee to supplied flatfee.
+        Transaction txWhereFeeIsNullFlatFeeIsPresent = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee((BigInteger) null)
+                .flatFee(100)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+        assertThat(txWhereFeeIsNullFlatFeeIsPresent.fee).isEqualTo(100);
+
+        // If flatFee is not present, but fee is null, set value of
+        // fee to Account.MIN_TX_FEE_UALGOS.
+        Transaction txWhereFeeIsNullFlatFeeIsNotPresent = Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee((BigInteger) null)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build();
+        assertThat(txWhereFeeIsNullFlatFeeIsNotPresent.fee).isEqualTo(Account.MIN_TX_FEE_UALGOS);
+
+        // If both fee and flatFee is preset, that is an
+        // illegal state and exception is thrown.
+        IllegalArgumentException exceptionWhenFeeAndFlatFeeIsNotNull =
+                assertThrows(IllegalArgumentException.class, () -> Transaction.AssetCreateTransactionBuilder()
+                .sender(sender)
+                .fee(10)
+                .flatFee(10)
+                .firstValid(322575)
+                .lastValid(323575)
+                .genesisHash(gh)
+                .assetTotal(100)
+                .assetDecimals(5)
+                .assetUnitName("tst")
+                .assetName("testcoin")
+                .url("https://example.com")
+                .metadataHashB64(metadataHashB64)
+                .manager(manager)
+                .reserve(reserve)
+                .freeze(freeze)
+                .clawback(clawback)
+                .build());
+        assertNotNull(exceptionWhenFeeAndFlatFeeIsNotNull);
+    }
+
 
     private void createAssetTest(int numDecimal, String goldenString) throws Exception {
         Address addr = new Address("BH55E5RMBD4GYWXGX5W5PJ5JAHPGM5OXKDQH5DC4O2MGI7NW4H6VOE4CP4");


### PR DESCRIPTION
This PR contains two changes related to this [issue](https://github.com/algorand/java-algorand-sdk/issues/523).
1. Allowing null for fee and flatfee in Long and Integer builder methods.
2. Adding unit test for testing behaviour of transaction builder if fee and flatfee is null. (#523)

Continuation of discussion [here](https://github.com/algorand/java-algorand-sdk/issues/523#issuecomment-1857197644), I think we do not need to add check to null out flatfee if fee is set and vice versa. The builder logic goes like this ([code](https://github.com/subhakundu/java-algorand-sdk/blob/develop/src/main/java/com/algorand/algosdk/builder/transaction/TransactionBuilder.java#L55))

1. If fee and flatfee are set, we throw an exception. Two values cannot be present in same transaction.
2. If fee and flatfee are null, we set fee to minimum value i.e., 1000 Algos ([code](https://github.com/subhakundu/java-algorand-sdk/blob/develop/src/main/java/com/algorand/algosdk/builder/transaction/TransactionBuilder.java#L59)). I hope I am using right terminologies. Please pardon my mistakes.
3. If fee is not null, we ignore flatfee altogether. If fee is set as null after setting passed fee value, we set fee in the transaction to the minimum value (1000 Algos).
4. If flatfee is null, fee is set to flatfee in the transaction. This is the case where flatfee is used if fee is null.

I have added a unit test to check various scenarios. If not needed, I can remove it. But I believe it will help document different scenarios in better manner. Please let me know your suggestions and concerns.

I have tested the code by running `mvn package` and `mvn clean test` locally.
