### PR TITLE
Fixes on Account and Transaction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <maven.surefire.version>3.0.0-M5</maven.surefire.version>
 
         <!-- Test sources at 1.8 to allow using JUnit5 -->
-        <java.version>1.7</java.version>
-        <java.release.version>7</java.release.version>
+        <java.version>1.8</java.version>
+        <java.release.version>8</java.release.version>
         <java.test.release.version>8</java.test.release.version>
 
         <!-- github server corresponds to entry in ~/.m2/settings.xml -->

--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -1,6 +1,5 @@
 package com.algorand.algosdk.transaction;
 
-import com.algorand.algosdk.account.Account;
 import com.algorand.algosdk.builder.transaction.*;
 import com.algorand.algosdk.crypto.*;
 import com.algorand.algosdk.logic.StateSchema;
@@ -352,7 +351,7 @@ public class Transaction implements Serializable {
     ) {
         if (type != null) this.type = type;
         if (sender != null) this.sender = sender;
-        this.fee = (fee == null ? Account.MIN_TX_FEE_UALGOS : fee);
+        this.fee = (fee == null ? BigInteger.valueOf(0) : fee);
         if (firstValid != null) this.firstValid = firstValid;
         if (lastValid != null) this.lastValid = lastValid;
         setNote(note);

--- a/src/main/java/com/algorand/algosdk/v2/client/model/Account.java
+++ b/src/main/java/com/algorand/algosdk/v2/client/model/Account.java
@@ -220,6 +220,13 @@ public class Account extends PathResponse {
     @JsonProperty("total-created-assets")
     public Long totalCreatedAssets;
 
+    /**
+     * MicroAlgo balance required by the account.
+     * The requirement grows based on asset and application usage.
+     */
+    @JsonProperty("min-balance")
+    public Long minBalance;
+
     @Override
     public boolean equals(Object o) {
 
@@ -253,6 +260,7 @@ public class Account extends PathResponse {
         if (!Objects.deepEquals(this.totalBoxes, other.totalBoxes)) return false;
         if (!Objects.deepEquals(this.totalCreatedApps, other.totalCreatedApps)) return false;
         if (!Objects.deepEquals(this.totalCreatedAssets, other.totalCreatedAssets)) return false;
+        if (!Objects.deepEquals(this.minBalance, other.minBalance)) return false;
 
         return true;
     }


### PR DESCRIPTION
Pull request includes two fixes:
1. min-balance attribute added in order to align sdk Account model to the ReST API response
2. removing Transaction.fee initialization at 1000 microAlgos in case of null variable. Fix is necessary for response deserialization in case of transaction submitted with no fees, in particular in case of Atomic Transaction pooled fees. In case of single transaction, if no fee is set, the transaction will be rejected by the chain.