### PR TITLE
ci: upgrade checkout action to v4

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Generate and PR
         uses: algorand/generator/.github/actions/sdk-codegen/@master
         with:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-type-category.yml
+++ b/.github/workflows/pr-type-category.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check PR Category and Type
     steps:
       - name: Checking for correct number of required github pr labels
-        uses: mheap/github-action-required-labels@v3
+        uses: mheap/github-action-required-labels@v5
         with:
           mode: exactly
           count: 1


### PR DESCRIPTION
## Summary
 - Upgrade checkout action to `v4` (`v3` is deprecated and throwing warnings)

## Testing Plan
 - Check `Node.js 16` warning messages go away after next CI codegen run