### PR TITLE
Tests: Update .test-env to use Cucumber specs from master

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 # Configs for testing repo download:
 SDK_TESTING_URL="https://github.com/algorand/algorand-sdk-testing"
-SDK_TESTING_BRANCH="V2"
+SDK_TESTING_BRANCH="master"
 SDK_TESTING_HARNESS="test-harness"
 
 INSTALL_ONLY=0


### PR DESCRIPTION
Update .test-env to use Cucumber specs from master rather than the now deprecated V2.