### PR TITLE
fix: removing Transaction.fee initialization at 1000 microAlgos

### DIFF
--- a/src/main/java/com/algorand/algosdk/transaction/Transaction.java
+++ b/src/main/java/com/algorand/algosdk/transaction/Transaction.java
@@ -352,7 +352,7 @@ public class Transaction implements Serializable {
     ) {
         if (type != null) this.type = type;
         if (sender != null) this.sender = sender;
-        this.fee = (fee == null ? Account.MIN_TX_FEE_UALGOS : fee);
+        this.fee = (fee == null ? BigInteger.ZERO : fee);
         if (firstValid != null) this.firstValid = firstValid;
         if (lastValid != null) this.lastValid = lastValid;
         setNote(note);

--- a/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
+++ b/src/test/java/com/algorand/algosdk/transaction/TestTransaction.java
@@ -584,7 +584,7 @@ public class TestTransaction {
 
         Transaction tx1 = Transaction.PaymentTransactionBuilder()
                 .sender(from)
-                .flatFee(fee)
+                .flatFee(0)
                 .firstValid(firstRound1)
                 .lastValid(firstRound1.longValue() + 1000)
                 .note(note1)
@@ -613,7 +613,7 @@ public class TestTransaction {
         assertThat(Encoder.decodeFromMsgPack(Encoder.encodeToMsgPack(tx1), Transaction.class)).isEqualTo(tx1);
         assertThat(Encoder.decodeFromMsgPack(Encoder.encodeToMsgPack(tx2), Transaction.class)).isEqualTo(tx2);
 
-        String goldenTx1 = "gaN0eG6Ko2FtdM0H0KNmZWXNA+iiZnbOAArW/6NnZW6rZGV2bmV0LXYxLjCiZ2jEILAtz+3tknW6iiStLW4gnSvbXUqW3ul3ghinaDc5pY9Bomx2zgAK2uekbm90ZcQIwRKw5cJ0CMqjcmN2xCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKNzbmTEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0spHR5cGWjcGF5";
+        String goldenTx1 = "gaN0eG6Jo2FtdM0H0KJmds4ACtb/o2dlbqtkZXZuZXQtdjEuMKJnaMQgsC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0GibHbOAAra56Rub3RlxAjBErDlwnQIyqNyY3bEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0so3NuZMQgo/ACrPJD2Jcet6aY9cOeNdKpDERmfRWKHzWD18RqTSykdHlwZaNwYXk=";
         String goldenTx2 = "gaN0eG6Ko2FtdM0H0KNmZWXNA+iiZnbOAArXc6NnZW6rZGV2bmV0LXYxLjCiZ2jEILAtz+3tknW6iiStLW4gnSvbXUqW3ul3ghinaDc5pY9Bomx2zgAK21ukbm90ZcQIdBlHI6BdrIijcmN2xCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKNzbmTEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0spHR5cGWjcGF5";
 
         // goal clerk send dumps unsigned transaction as signed with empty signature in order to save tx type
@@ -636,7 +636,7 @@ public class TestTransaction {
 
         // goal clerk group sets Group to every transaction and concatenate them in output file
         // simulating that behavior here
-        String goldenTxg = "gaN0eG6Lo2FtdM0H0KNmZWXNA+iiZnbOAArW/6NnZW6rZGV2bmV0LXYxLjCiZ2jEILAtz+3tknW6iiStLW4gnSvbXUqW3ul3ghinaDc5pY9Bo2dycMQgLiQ9OBup9H/bZLSfQUH2S6iHUM6FQ3PLuv9FNKyt09SibHbOAAra56Rub3RlxAjBErDlwnQIyqNyY3bEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0so3NuZMQgo/ACrPJD2Jcet6aY9cOeNdKpDERmfRWKHzWD18RqTSykdHlwZaNwYXmBo3R4boujYW10zQfQo2ZlZc0D6KJmds4ACtdzo2dlbqtkZXZuZXQtdjEuMKJnaMQgsC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0GjZ3JwxCAuJD04G6n0f9tktJ9BQfZLqIdQzoVDc8u6/0U0rK3T1KJsds4ACttbpG5vdGXECHQZRyOgXayIo3JjdsQgo/ACrPJD2Jcet6aY9cOeNdKpDERmfRWKHzWD18RqTSyjc25kxCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKR0eXBlo3BheQ==";
+        String goldenTxg = "gaN0eG6Ko2FtdM0H0KJmds4ACtb/o2dlbqtkZXZuZXQtdjEuMKJnaMQgsC3P7e2SdbqKJK0tbiCdK9tdSpbe6XeCGKdoNzmlj0GjZ3JwxCB8ppMbrB2uVjcuaRC9jTEfXSycZ16eEhPeUXdJ/SVWM6Jsds4ACtrnpG5vdGXECMESsOXCdAjKo3JjdsQgo/ACrPJD2Jcet6aY9cOeNdKpDERmfRWKHzWD18RqTSyjc25kxCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKR0eXBlo3BheYGjdHhui6NhbXTNB9CjZmVlzQPoomZ2zgAK13OjZ2Vuq2Rldm5ldC12MS4womdoxCCwLc/t7ZJ1uookrS1uIJ0r211Klt7pd4IYp2g3OaWPQaNncnDEIHymkxusHa5WNy5pEL2NMR9dLJxnXp4SE95Rd0n9JVYzomx2zgAK21ukbm90ZcQIdBlHI6BdrIijcmN2xCCj8AKs8kPYlx63ppj1w5410qkMRGZ9FYofNYPXxGpNLKNzbmTEIKPwAqzyQ9iXHremmPXDnjXSqQxEZn0Vih81g9fEak0spHR5cGWjcGF5";
         stx1 = new SignedTransaction(tx1, new Signature(), new MultisigSignature(), new LogicsigSignature(), tx1.txID());
         stx2 = new SignedTransaction(tx2, new Signature(), new MultisigSignature(), new LogicsigSignature(), tx2.txID());
         byte[] stx1Enc = Encoder.encodeToMsgPack(stx1);


### PR DESCRIPTION
removing Transaction.fee initialization at 1000 microAlgos in case of null variable. Fix is necessary for response deserialization in case of transaction submitted with no fees, in particular in case of Atomic Transaction pooled fees. If case of single transaction, if no fee is set, the transaction will be rejected by the chain.