### PR TITLE
ci: update linux image for integration test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run: mvn test
   integration-test:
     machine:
-      image: "ubuntu-2204:2022.04.2"
+      image: default
     resource_class: medium
     steps:
       - checkout


### PR DESCRIPTION
## Summary
 - Update circleci image to latest stable version.   Current one is deprecated: https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

## Testing Plan
 - Integration test job should pass