### PR TITLE
Build: Update Box API Pagination-dependent integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run: mvn test
   integration-test:
     machine:
-      image: "ubuntu-2204:2022.10.2"
+      image: "ubuntu-2404:2024.11.1"
     resource_class: medium
     steps:
       - checkout


### PR DESCRIPTION
The pagination support on the Algod boxes endpoint depends solely on what box information has been persisted within algod. Previously, integration tests could assume once a transaction to add a box was approved, it was queryable. This PR introduces check and wait semantics to give ample time for the boxes to be made available via API.