### PR TITLE
Build: Remove explicit 'wait until published' flag from central-maven-publis…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,6 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
 


### PR DESCRIPTION
…hing plugin. The default is to wait until validated, which is sufficient for our purposes.