### PR TITLE
CICD: run tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,40 @@
+name: CI - Test Suite
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK 11 for x64
+        uses: actions/setup-java@v4
+        with:
+            java-version: '11'
+            distribution: 'temurin'
+            architecture: x64
+      - name: Run unit tests
+        run: mvn test
+
+  integration-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up JDK 11 for x64
+        uses: actions/setup-java@v4
+        with:
+            java-version: '11'
+            distribution: 'temurin'
+            architecture: x64
+      - name: Run cucumber unit and integration tests
+        run: make ci-test

--- a/.github/workflows/pr-type-category.yml
+++ b/.github/workflows/pr-type-category.yml
@@ -2,7 +2,7 @@ name: Check PR category and type
 on:
   pull_request:
     branches:
-      - develop
+      - main
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 jobs:
   check_label:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM adoptopenjdk/maven-openjdk11
 RUN apt-get update && apt-get install -y make
 
 # Copy SDK code into the container
-RUN mkdir -p $HOME/java-algorand-sdk
-COPY . $HOME/java-algorand-sdk
-WORKDIR $HOME/java-algorand-sdk
+RUN mkdir -p /app/java-algorand-sdk
+COPY . /app/java-algorand-sdk
+WORKDIR /app/java-algorand-sdk
 
 # Run integration tests
 CMD ["/bin/bash", "-c", "make unit && make integration"]

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ docker-javasdk-build:
 
 docker-javasdk-run:
 	# Launch SDK testing
-	docker run -it --network host java-sdk-testing:latest
+	docker run -t --network host java-sdk-testing:latest
 
 docker-test: harness docker-javasdk-build docker-javasdk-run
+
+ci-test: harness unit integration
+
+.PHONY: ci-test


### PR DESCRIPTION
## Summary

This is an implementation of unit and integration tests in GitHub Actions.

The building of a container just to execute tests was removed from this build.

Additionally, the PR category/type check was modified to check PRs versus main instead of develop.

## Testing

Verify that these and CircleCI tests still pass.
